### PR TITLE
Feature/week1/user point

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/point/PointFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/point/PointFacade.java
@@ -19,4 +19,9 @@ public class PointFacade {
         PointModel pointModel = pointService.getPointModelByLoginId(loginId);
         return PointInfo.from(pointModel);
     }
+
+    public PointInfo chargePoint(String loginId, Long amount) {
+        PointModel pointModel = pointService.chargePoint(loginId, amount);
+        return PointInfo.from(pointModel);
+    }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/point/PointFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/point/PointFacade.java
@@ -1,0 +1,22 @@
+package com.loopers.application.point;
+
+import com.loopers.domain.point.PointModel;
+import com.loopers.domain.point.PointService;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class PointFacade {
+    private final PointService pointService;
+
+    public PointInfo getPointInfoByLoginId(String loginId) {
+        if(loginId == null || loginId.isEmpty()) {
+            throw new CoreException(ErrorType.BAD_REQUEST);
+        }
+        PointModel pointModel = pointService.getPointModelByLoginId(loginId);
+        return PointInfo.from(pointModel);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/point/PointInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/point/PointInfo.java
@@ -2,12 +2,11 @@ package com.loopers.application.point;
 
 import com.loopers.domain.point.PointModel;
 
-public record PointInfo(String loginId, Long amount, Long totalAmount) {
+public record PointInfo(String loginId, Long amount) {
     public static PointInfo from(PointModel point){
         return new PointInfo(
                 point.getLoginId(),
-                point.getAmount(),
-                point.getTotalAmount()
+                point.getAmount()
         );
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/application/point/PointInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/point/PointInfo.java
@@ -1,0 +1,13 @@
+package com.loopers.application.point;
+
+import com.loopers.domain.point.PointModel;
+
+public record PointInfo(String loginId, Long amount, Long totalAmount) {
+    public static PointInfo from(PointModel point){
+        return new PointInfo(
+                point.getLoginId(),
+                point.getAmount(),
+                point.getTotalAmount()
+        );
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/user/UserFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/user/UserFacade.java
@@ -24,6 +24,7 @@ public class UserFacade {
     }
 
     public UserInfo getUserInfoByLoginId(String loginId){
+
         UserModel user = userService.getUserByLoginId(loginId);
         if(user == null){
             throw new CoreException(ErrorType.NOT_FOUND);

--- a/apps/commerce-api/src/main/java/com/loopers/application/user/UserFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/user/UserFacade.java
@@ -2,6 +2,8 @@ package com.loopers.application.user;
 
 import com.loopers.domain.user.UserModel;
 import com.loopers.domain.user.UserService;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -19,6 +21,14 @@ public class UserFacade {
         );
         return UserInfo.from(user);
 
+    }
+
+    public UserInfo getUserInfoByLoginId(String loginId){
+        UserModel user = userService.getUserByLoginId(loginId);
+        if(user == null){
+            throw new CoreException(ErrorType.NOT_FOUND);
+        }
+        return UserInfo.from(user);
     }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointModel.java
@@ -1,6 +1,8 @@
 package com.loopers.domain.point;
 
 import com.loopers.domain.BaseEntity;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import lombok.Getter;
@@ -12,13 +14,19 @@ public class PointModel extends BaseEntity {
 
     private String loginId;
     private Long amount;
-    private Long totalAmount;
 
     protected PointModel() {}
 
-    public PointModel(String loginId, Long amount, Long totalAmount) {
+    public PointModel(String loginId, Long amount) {
         this.loginId = loginId;
         this.amount = amount;
-        this.totalAmount = totalAmount;
+    }
+
+    public void chargePoint(Long chargeAmount) {
+        if(chargeAmount == null || chargeAmount <= 0) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "충전 금액은 0보다 커야 합니다.");
+        }
+
+        this.amount += chargeAmount;
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointModel.java
@@ -1,0 +1,24 @@
+package com.loopers.domain.point;
+
+import com.loopers.domain.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Getter;
+
+@Entity
+@Getter
+@Table(name="point")
+public class PointModel extends BaseEntity {
+
+    private String loginId;
+    private Long amount;
+    private Long totalAmount;
+
+    protected PointModel() {}
+
+    public PointModel(String loginId, Long amount, Long totalAmount) {
+        this.loginId = loginId;
+        this.amount = amount;
+        this.totalAmount = totalAmount;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.point;
+
+public interface PointRepository {
+
+    PointModel save(PointModel point);
+    PointModel findPointByLoginId(String loginId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
@@ -1,5 +1,9 @@
 package com.loopers.domain.point;
 
+import com.loopers.domain.user.UserModel;
+import com.loopers.domain.user.UserRepository;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -10,8 +14,18 @@ import org.springframework.stereotype.Component;
 public class PointService {
 
     private final PointRepository pointRepository;
+    private final UserRepository userRepository;
 
     public PointModel getPointModelByLoginId(String loginId) {
         return pointRepository.findPointByLoginId(loginId);
+    }
+
+    public PointModel chargePoint(String loginId, Long amount) {
+        if(!userRepository.existsByLoginId(loginId)) {
+            throw new CoreException(ErrorType.NOT_FOUND);
+        }
+        PointModel pointModel = pointRepository.findPointByLoginId(loginId);
+        pointModel.chargePoint(amount);
+        return pointRepository.save(pointModel);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
@@ -1,0 +1,17 @@
+package com.loopers.domain.point;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PointService {
+
+    private final PointRepository pointRepository;
+
+    public PointModel getPointModelByLoginId(String loginId) {
+        return pointRepository.findPointByLoginId(loginId);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserRepository.java
@@ -9,4 +9,5 @@ public interface UserRepository {
 
     boolean existsByLoginId(String loginId);
 
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/user/UserService.java
@@ -4,8 +4,10 @@ import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class UserService {
@@ -22,4 +24,10 @@ public class UserService {
         UserModel user = new UserModel(loginId, email, birth, gender);
         return userRepository.save(user);
     }
+
+    public UserModel getUserByLoginId(String loginId){
+        return userRepository.findByLoginId(loginId)
+                .orElse(null);
+    }
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointJpaRepository.java
@@ -1,0 +1,12 @@
+package com.loopers.infrastructure.point;
+
+import com.loopers.domain.point.PointModel;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PointJpaRepository extends JpaRepository<PointModel, Long> {
+
+    Optional<PointModel> findPointByLoginId(String loginId);
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointRepositoryImpl.java
@@ -1,0 +1,23 @@
+package com.loopers.infrastructure.point;
+
+import com.loopers.domain.point.PointModel;
+import com.loopers.domain.point.PointRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class PointRepositoryImpl implements PointRepository {
+    private final PointJpaRepository pointJpaRepository;
+
+    @Override
+    public PointModel save(PointModel point) {
+        return pointJpaRepository.save(point);
+    }
+
+    @Override
+    public PointModel findPointByLoginId(String loginId) {
+        return pointJpaRepository.findPointByLoginId(loginId)
+                .orElse(null);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiSpec.java
@@ -4,6 +4,7 @@ import com.loopers.interfaces.api.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 
 @Tag(name = "Point V1 API", description = "Point 관련 API 입니다.")
@@ -17,5 +18,13 @@ public interface PointV1ApiSpec {
             @RequestHeader("X-USER-ID")
             @Schema(description = "유저 식별자 (loginId)", example = "test123")
             String loginId
+    );
+
+    @Operation(
+            summary = "포인트 충전",
+            description = "등록된 유저의 포인트를 충전합니다."
+    )
+    ApiResponse<PointV1Dto.PointResponse> chargePoints(
+            @RequestBody PointV1Dto.PointChargeRequest request
     );
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1ApiSpec.java
@@ -1,0 +1,21 @@
+package com.loopers.interfaces.api.point;
+
+import com.loopers.interfaces.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@Tag(name = "Point V1 API", description = "Point 관련 API 입니다.")
+public interface PointV1ApiSpec {
+
+    @Operation(
+            summary = "포인트 조회",
+            description = "등록된 유저의 포인트를 조회합니다."
+    )
+    ApiResponse<PointV1Dto.PointResponse> getPoints(
+            @RequestHeader("X-USER-ID")
+            @Schema(description = "유저 식별자 (loginId)", example = "test123")
+            String loginId
+    );
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Controller.java
@@ -3,14 +3,9 @@ package com.loopers.interfaces.api.point;
 import com.loopers.application.point.PointFacade;
 import com.loopers.application.point.PointInfo;
 import com.loopers.interfaces.api.ApiResponse;
-import com.loopers.support.error.CoreException;
-import com.loopers.support.error.ErrorType;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
+
 
 @RestController
 @RequiredArgsConstructor
@@ -27,4 +22,15 @@ public class PointV1Controller implements PointV1ApiSpec{
       PointInfo pointInfo = pointFacade.getPointInfoByLoginId(loginId);
       return ApiResponse.success(PointV1Dto.PointResponse.from(pointInfo));
     }
+
+    @PostMapping("/charge")
+    @Override
+    public ApiResponse<PointV1Dto.PointResponse> chargePoints(
+            @RequestBody PointV1Dto.PointChargeRequest request) {
+        PointInfo pointInfo = pointFacade.chargePoint(request.loginId(), request.amount());
+        return ApiResponse.success(PointV1Dto.PointResponse.from(pointInfo));
+
+    }
+
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Controller.java
@@ -1,0 +1,30 @@
+package com.loopers.interfaces.api.point;
+
+import com.loopers.application.point.PointFacade;
+import com.loopers.application.point.PointInfo;
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/points")
+public class PointV1Controller implements PointV1ApiSpec{
+
+    private final PointFacade pointFacade;
+
+    @GetMapping
+    @Override
+    public ApiResponse<PointV1Dto.PointResponse> getPoints(
+            @RequestHeader("X-USER-ID")  String loginId
+    ) {
+      PointInfo pointInfo = pointFacade.getPointInfoByLoginId(loginId);
+      return ApiResponse.success(PointV1Dto.PointResponse.from(pointInfo));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Dto.java
@@ -1,0 +1,26 @@
+package com.loopers.interfaces.api.point;
+
+import com.loopers.application.point.PointInfo;
+
+public class PointV1Dto {
+
+    public record PointRequest(
+            String loginId,
+            Long amount, // 충전 금액
+            Long totalAmount // 총 충전 금액
+    ){}
+
+    public record PointResponse(
+            String loginId,
+            Long amount,
+            Long totalAmount
+    ){
+        public static PointResponse from(PointInfo pointInfo) {
+            return new PointResponse(
+                    pointInfo.loginId(),
+                    pointInfo.amount(),
+                    pointInfo.totalAmount()
+            );
+        };
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Dto.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/point/PointV1Dto.java
@@ -4,22 +4,19 @@ import com.loopers.application.point.PointInfo;
 
 public class PointV1Dto {
 
-    public record PointRequest(
+    public record PointChargeRequest(
             String loginId,
-            Long amount, // 충전 금액
-            Long totalAmount // 총 충전 금액
+            Long amount // 충전 금액
     ){}
 
     public record PointResponse(
             String loginId,
-            Long amount,
-            Long totalAmount
+            Long amount
     ){
         public static PointResponse from(PointInfo pointInfo) {
             return new PointResponse(
                     pointInfo.loginId(),
-                    pointInfo.amount(),
-                    pointInfo.totalAmount()
+                    pointInfo.amount()
             );
         };
     }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
@@ -18,7 +18,14 @@ public interface UserV1ApiSpec {
             @Schema(description = "유저 등록 요청 정보") UserV1Dto.RegisterUserRequest registerUserRequest
     );
 
-    @GetMapping("/me")
+    @Operation(
+            summary = "유저 조회",
+            description = "등록된 유저 정보를 조회합니다."
+    )
     ApiResponse<UserV1Dto.UsersResponse> getUsers(
-            @RequestHeader("X-USER-ID") String loginId);
+            @RequestHeader("X-USER-ID")
+            @Schema(description = "유저 식별자 (loginId)", example = "test123")
+            String loginId
+    );
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1ApiSpec.java
@@ -4,6 +4,8 @@ import com.loopers.interfaces.api.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 
 @Tag(name = "Users V1 API", description = "User 관련 API 입니다.")
 public interface UserV1ApiSpec {
@@ -15,4 +17,8 @@ public interface UserV1ApiSpec {
     ApiResponse<UserV1Dto.UsersResponse> registerUser(
             @Schema(description = "유저 등록 요청 정보") UserV1Dto.RegisterUserRequest registerUserRequest
     );
+
+    @GetMapping("/me")
+    ApiResponse<UserV1Dto.UsersResponse> getUsers(
+            @RequestHeader("X-USER-ID") String loginId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserV1Controller implements UserV1ApiSpec {
     private final UserFacade userFacade;
 
-    @PostMapping("/register")
+    @PostMapping
     @Override
     public ApiResponse<UserV1Dto.UsersResponse> registerUser(
             @RequestBody UserV1Dto.RegisterUserRequest request

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
@@ -31,8 +31,15 @@ public class UserV1Controller implements UserV1ApiSpec {
     @Override
     public ApiResponse<UserV1Dto.UsersResponse> getUsers(
             @RequestHeader("X-USER-ID") String loginId) {
-        UserInfo userInfo = userFacade.getUserInfoByLoginId(loginId);
-        return ApiResponse.success(UserV1Dto.UsersResponse.from(userInfo));
+        return ApiResponse.success(
+                new UserV1Dto.UsersResponse(
+                        1L,
+                        loginId,
+                        "test@test.com",
+                        "1999-01-01",
+                        "M"
+                )
+        );
     }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
@@ -4,10 +4,7 @@ import com.loopers.application.user.UserFacade;
 import com.loopers.application.user.UserInfo;
 import com.loopers.interfaces.api.ApiResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -29,4 +26,13 @@ public class UserV1Controller implements UserV1ApiSpec {
 
         return ApiResponse.success(UserV1Dto.UsersResponse.from(userInfo));
     }
+
+    @GetMapping("/me")
+    @Override
+    public ApiResponse<UserV1Dto.UsersResponse> getUsers(
+            @RequestHeader("X-USER-ID") String loginId) {
+        UserInfo userInfo = userFacade.getUserInfoByLoginId(loginId);
+        return ApiResponse.success(UserV1Dto.UsersResponse.from(userInfo));
+    }
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
+++ b/apps/commerce-api/src/main/java/com/loopers/interfaces/api/user/UserV1Controller.java
@@ -31,15 +31,9 @@ public class UserV1Controller implements UserV1ApiSpec {
     @Override
     public ApiResponse<UserV1Dto.UsersResponse> getUsers(
             @RequestHeader("X-USER-ID") String loginId) {
-        return ApiResponse.success(
-                new UserV1Dto.UsersResponse(
-                        1L,
-                        loginId,
-                        "test@test.com",
-                        "1999-01-01",
-                        "M"
-                )
-        );
+
+        UserInfo userInfo = userFacade.getUserInfoByLoginId(loginId);
+        return ApiResponse.success(UserV1Dto.UsersResponse.from(userInfo));
     }
 
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/example/ExampleServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/example/ExampleServiceIntegrationTest.java
@@ -69,4 +69,5 @@ class ExampleServiceIntegrationTest {
             assertThat(exception.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
         }
     }
+
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/point/PointModelTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/point/PointModelTest.java
@@ -1,0 +1,31 @@
+package com.loopers.domain.point;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class PointModelTest {
+    @DisplayName("포인트를 충전할 때,")
+    @Nested
+    class Create {
+        @DisplayName("0 이하의 정수로 포인트를 충전 시 실패한다.")
+        @Test
+        void throwBadRequest_whenChargeAmountIsZeroOrNegative() {
+            // arrange
+            PointModel pointModel = new PointModel("test123", 1000L);
+
+            // act
+            CoreException result = assertThrows(CoreException.class, () -> {
+                    pointModel.chargePoint(-200L);
+            });
+
+            // assert
+            assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
@@ -1,7 +1,10 @@
 package com.loopers.domain.point;
 
 import com.loopers.infrastructure.point.PointJpaRepository;
+import com.loopers.interfaces.api.point.PointV1ApiSpec;
 import com.loopers.interfaces.api.point.PointV1Dto;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
 import com.loopers.utils.DatabaseCleanUp;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
@@ -13,6 +16,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 
 @Slf4j
@@ -41,8 +45,7 @@ public class PointServiceIntegrationTest {
             PointModel savepoint = pointJpaRepository.save(
                     new PointModel(
                             "test1234",
-                            1000L,
-                            10000L
+                            1000L
                     )
             );
 
@@ -61,8 +64,7 @@ public class PointServiceIntegrationTest {
             pointJpaRepository.save(
                     new PointModel(
                             "test1234",
-                            1000L,
-                            10000L
+                            1000L
                     )
             );
 
@@ -71,6 +73,34 @@ public class PointServiceIntegrationTest {
 
             // assert
             assertThat(result).isNull();
+        }
+    }
+
+    @DisplayName("포인트 충전할 때,")
+    @Nested
+    class ChargePoint{
+        @DisplayName("존재하지 않는 유저 ID 로 충전을 시도한 경우, 실패한다.")
+        @Test
+        void throwException_whenLoginIdIsNotExists(){
+            // arrange
+            PointModel pointModel = pointJpaRepository.save(
+                    new PointModel(
+                            "test1234",
+                            1000L
+                    )
+            );
+
+            // act
+            CoreException result =
+                    assertThrows(CoreException.class,
+                            () -> pointService.chargePoint(
+                                    "1111",
+                                    pointModel.getAmount()
+                            ));
+
+
+            // assert
+            assertThat(result.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
         }
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/point/PointServiceIntegrationTest.java
@@ -1,0 +1,76 @@
+package com.loopers.domain.point;
+
+import com.loopers.infrastructure.point.PointJpaRepository;
+import com.loopers.interfaces.api.point.PointV1Dto;
+import com.loopers.utils.DatabaseCleanUp;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+@Slf4j
+@SpringBootTest
+public class PointServiceIntegrationTest {
+
+    @Autowired
+    private PointService pointService;
+
+    @SpyBean
+    private PointJpaRepository pointJpaRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    public void tearDown() { databaseCleanUp.truncateAllTables(); }
+
+    @DisplayName("포인트 조회할 때,")
+    @Nested
+    class GetPoint{
+        @DisplayName("해당 ID 의 회원이 존재할 경우, 보유 포인트가 반환된다.")
+        @Test
+        void returnTotalAmount_whenLoginIdIsExists(){
+            // arrange
+            PointModel savepoint = pointJpaRepository.save(
+                    new PointModel(
+                            "test1234",
+                            1000L,
+                            10000L
+                    )
+            );
+
+            // act
+            pointService.getPointModelByLoginId(savepoint.getLoginId());
+
+            // verify
+            verify(pointJpaRepository).findPointByLoginId(savepoint.getLoginId());
+
+        }
+
+        @DisplayName("해당 ID 의 회원이 존재하지 않을 경우, null 이 반환된다.")
+        @Test
+        void returnNull_whenLoginIdIsNotExists(){
+            // arrange
+            pointJpaRepository.save(
+                    new PointModel(
+                            "test1234",
+                            1000L,
+                            10000L
+                    )
+            );
+
+            // act
+            PointModel result = pointService.getPointModelByLoginId("1111");
+
+            // assert
+            assertThat(result).isNull();
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserModelTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserModelTest.java
@@ -1,0 +1,68 @@
+package com.loopers.domain.user;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class UserModelTest {
+    @DisplayName("User 객체를 생성할 때,")
+    @Nested
+    class Create{
+        @DisplayName("ID가 영문 및 숫자 10자 이내 형식에 맞지 않으면 User 객체 생성에 실패한다.")
+        @Test
+        void throwBadRequestException_whenLoginIdFormatIsInvalid(){
+            // arrange
+            String loginId = "testtest1234";
+
+            // act
+            CoreException result = assertThrows(CoreException.class, () -> {
+                new UserModel(
+                        loginId,
+                        "email@email.com",
+                        "1999-01-01",
+                        "W"
+                );
+            });
+
+            // assert
+            assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+        @DisplayName("이메일이 xx@yy.zz 형식에 맞지 않으면 User 객체 생성에 실패한다.")
+        @Test
+        void throwBadRequestException_whenEmailFormatIsInvalid(){
+            String email = "xx@aaaa";
+
+            CoreException result = assertThrows(CoreException.class, () -> {
+                new UserModel(
+                        "test1234",
+                        email,
+                        "1999-01-01",
+                        "W"
+                );
+            });
+            assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+
+        @DisplayName("생년월일이 yyyy-mm-dd 형식에 맞지 않으면, User 객체 생성에 실패한다.")
+        @Test
+        void throwBadRequestException_whenBirthFormatIsInvalid(){
+            String birth = "19990101";
+            CoreException result = assertThrows(CoreException.class, () -> {
+                new UserModel(
+                        "test1234",
+                        "email@email.com",
+                        birth,
+                        "W"
+                );
+            });
+
+            assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
@@ -6,6 +6,7 @@ import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import com.loopers.utils.DatabaseCleanUp;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.catalina.User;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -16,6 +17,7 @@ import org.springframework.boot.test.mock.mockito.SpyBean;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 
 @Slf4j
@@ -95,6 +97,69 @@ public class UserServiceIntegrationTest {
 
             assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
 
+        }
+    }
+
+
+    /**
+     * ** 통합 테스트**
+     *
+     * - [ ]  해당 ID 의 회원이 존재할 경우, 회원 정보가 반환된다.
+     * - [ ]  해당 ID 의 회원이 존재하지 않을 경우, null 이 반환된다.
+     *
+     */
+    @DisplayName("User를 조회할 때,")
+    @Nested
+    class getUser{
+        @DisplayName("해당 ID 의 회원이 존재할 경우, 회원 정보가 반환된다.")
+        @Test
+        void returnUser_whenLoginIdExists() {
+            // arrange
+            UserV1Dto.RegisterUserRequest request = new UserV1Dto.RegisterUserRequest(
+                    "test1",
+                    "test1@test.test",
+                    "1999-01-01",
+                    "M"
+            );
+
+            userService.register(
+                    request.loginId(),
+                    request.email(),
+                    request.brith(),
+                    request.gender()
+            );
+
+            // act
+            userService.getUserByLoginId(request.loginId());
+
+            // verify
+            verify(userJpaRepository).findByLoginId(request.loginId());
+        }
+
+        @DisplayName("해당 ID 의 회원이 존재하지 않을 경우, null 이 반환된다.")
+        @Test
+        void returnNull_whenLoginIdDoesNotExist() {
+
+            // arrange
+            UserV1Dto.RegisterUserRequest request = new UserV1Dto.RegisterUserRequest(
+                    "test1",
+                    "test1@test.test",
+                    "1999-01-01",
+                    "M"
+            );
+
+            userService.register(
+                    request.loginId(),
+                    request.email(),
+                    request.brith(),
+                    request.gender()
+            );
+
+            // act
+              UserModel result = userService.getUserByLoginId("test");
+
+            // assert
+            assertThat(result).isNull();
         }
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/user/UserServiceIntegrationTest.java
@@ -1,0 +1,100 @@
+package com.loopers.domain.user;
+
+import com.loopers.infrastructure.user.UserJpaRepository;
+import com.loopers.interfaces.api.user.UserV1Dto;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import com.loopers.utils.DatabaseCleanUp;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+@Slf4j
+@SpringBootTest
+public class UserServiceIntegrationTest {
+    @Autowired
+    private UserService userService;
+
+    @SpyBean
+    private UserJpaRepository userJpaRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    public void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+
+    @DisplayName("User를 생성할 때,")
+    @Nested
+    class Register {
+        @DisplayName("회원가입 시 User가 저장된다.")
+        @Test
+        void saveUser_whenRegisterUser() {
+            // arrange
+            UserV1Dto.RegisterUserRequest request = new UserV1Dto.RegisterUserRequest(
+                    "test1",
+                     "test1@test.test",
+                     "1999-01-01",
+                    "M"
+            );
+
+            // act
+            userService.register(request.loginId(), request.email(), request.brith(), request.gender());
+
+            // verify
+            verify(userJpaRepository).save(org.mockito.Mockito.any(UserModel.class));
+
+        }
+
+        @DisplayName("이미 가입된 ID로 회원가입 시도 시, 실패한다.")
+        @Test
+        void throwException_whenRegisterUserWithDuplicateLoginId() {
+            // arrange
+            UserV1Dto.RegisterUserRequest request = new UserV1Dto.RegisterUserRequest(
+                    "test1",
+                    "test1@test.test",
+                    "1999-01-01",
+                    "M"
+            );
+
+            userService.register(
+                    request.loginId(),
+                    request.email(),
+                    request.brith(),
+                    request.gender()
+            );
+
+            // act
+            UserV1Dto.RegisterUserRequest duplicateRequest = new UserV1Dto.RegisterUserRequest(
+                    "test1",
+                    "test1@test.test",
+                    "1999-01-01",
+                    "M"
+            );
+
+            CoreException result = assertThrows(CoreException.class, () -> {
+                userService.register(
+                        duplicateRequest.loginId(),
+                        duplicateRequest.email(),
+                        duplicateRequest.brith(),
+                        duplicateRequest.gender()
+                );
+            });
+
+            assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/point/PointV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/point/PointV1ApiE2ETest.java
@@ -2,7 +2,9 @@ package com.loopers.interfaces.api.point;
 
 import com.loopers.application.point.PointInfo;
 import com.loopers.domain.point.PointModel;
+import com.loopers.domain.user.UserModel;
 import com.loopers.infrastructure.point.PointJpaRepository;
+import com.loopers.infrastructure.user.UserJpaRepository;
 import com.loopers.interfaces.api.ApiResponse;
 import com.loopers.utils.DatabaseCleanUp;
 import org.assertj.core.api.AssertionsForClassTypes;
@@ -28,6 +30,9 @@ public class PointV1ApiE2ETest {
 
     @Autowired
     private PointJpaRepository pointJpaRepository;
+
+    @Autowired
+    private UserJpaRepository userJpaRepository;
 
     @Autowired
     private DatabaseCleanUp databaseCleanUp;
@@ -119,9 +124,18 @@ public class PointV1ApiE2ETest {
         @Test
         void returnTotalAmount_whenExistingUserChargesPoints() {
             // arrange
+            String requestUrl = ENDPOINT + "/charge";
+            userJpaRepository.save(
+                    new UserModel(
+                            "test1234",
+                            "test@test.com",
+                            "1999-01-01",
+                            "M"
+                    )
+            );
             PointModel savePoint = pointJpaRepository.save(
                     new PointModel(
-                            "teet1234",
+                            "test1234",
                             1000L
                     )
             );
@@ -132,7 +146,6 @@ public class PointV1ApiE2ETest {
             );
 
             // act
-            String requestUrl = ENDPOINT + "/charge";
             ParameterizedTypeReference<ApiResponse<PointV1Dto.PointResponse>> responseType =
                     new ParameterizedTypeReference<>(){};
             ResponseEntity<ApiResponse<PointV1Dto.PointResponse>> response =

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/point/PointV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/point/PointV1ApiE2ETest.java
@@ -39,7 +39,7 @@ public class PointV1ApiE2ETest {
 
     private static final String ENDPOINT = "/api/v1/points";
 
-    @DisplayName("POST /api/v1/points")
+    @DisplayName("GET /api/v1/points")
     @Nested
     class GetPoints{
         /**

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/point/PointV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/point/PointV1ApiE2ETest.java
@@ -1,0 +1,116 @@
+package com.loopers.interfaces.api.point;
+
+import com.loopers.application.point.PointInfo;
+import com.loopers.domain.point.PointModel;
+import com.loopers.infrastructure.point.PointJpaRepository;
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.utils.DatabaseCleanUp;
+import org.assertj.core.api.AssertionsForClassTypes;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.*;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class PointV1ApiE2ETest {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private PointJpaRepository pointJpaRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    private static final String ENDPOINT = "/api/v1/points";
+
+    @DisplayName("POST /api/v1/points")
+    @Nested
+    class GetPoints{
+        /**
+         * **E2E 테스트**
+         * - [ o ]  포인트 조회에 성공할 경우, 보유 포인트를 응답으로 반환한다.
+         * - [ o ]  `X-USER-ID` 헤더가 없을 경우, `400 Bad Request` 응답을 반환한다.
+         * */
+
+        @DisplayName("포인트 조회에 성공할 경우, 보유 포인트를 응답으로 반환한다.")
+        @Test
+        void returnPointsTotalAmount_whenGetPointsIsSuccessful(){
+            // arrange
+            PointModel savePoint = pointJpaRepository.save(
+                    new PointModel(
+                            "test1234",
+                            1000L,
+                            10000L
+                    )
+            );
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.add("X-USER-ID", savePoint.getLoginId());
+            HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+            // act
+            ParameterizedTypeReference<ApiResponse<PointV1Dto.PointResponse>> responseType =
+                    new ParameterizedTypeReference<>(){};
+            ResponseEntity<ApiResponse<PointV1Dto.PointResponse>> response =
+                    restTemplate.exchange(
+                            ENDPOINT,
+                            HttpMethod.GET,
+                            entity,
+                            responseType
+            );
+
+            // assert
+            assertAll(
+                    () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
+                    () -> assertThat(response.getBody()).isNotNull(),
+                    () -> assertThat(response.getBody().data().totalAmount()).isEqualTo(10000)
+            );
+        }
+
+        @DisplayName("`X-USER-ID` 헤더가 없을 경우, `400 Bad Request` 응답을 반환한다.")
+        @Test
+        void throwBadRequestException_whenXUserIdIsMissing(){
+            // arrange
+            pointJpaRepository.save(
+                    new PointModel(
+                            "test1234",
+                            1000L,
+                            10000L
+                    )
+            );
+            HttpHeaders headers = new HttpHeaders();
+            headers.add("X-USER-ID", "");
+            HttpEntity<Void> entity = new HttpEntity<>(headers);
+            // act
+            ParameterizedTypeReference<ApiResponse<PointV1Dto.PointResponse>> responseType =
+                    new ParameterizedTypeReference<>(){};
+            ResponseEntity<ApiResponse<PointV1Dto.PointResponse>> response =
+                    restTemplate.exchange(
+                            ENDPOINT,
+                            HttpMethod.GET,
+                            entity,
+                            responseType
+
+                    );
+
+            // assert
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/user/UserV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/user/UserV1ApiE2ETest.java
@@ -5,6 +5,8 @@ import com.loopers.domain.user.UserService;
 import com.loopers.infrastructure.user.UserJpaRepository;
 import com.loopers.interfaces.api.ApiResponse;
 import com.loopers.utils.DatabaseCleanUp;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.catalina.User;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -13,24 +15,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+@Slf4j
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class UserV1ApiE2ETest {
-
-    /*
-    *** E2E 테스트**
-    - [o]  회원 가입이 성공할 경우, 생성된 유저 정보를 응답으로 반환한다.
-    - [ ]  회원 가입 시에 성별이 없을 경우, `400 Bad Request` 응답을 반환한다.
-    *
-    * */
-
 
     @Autowired
     private TestRestTemplate testRestTemplate ;
@@ -47,21 +39,22 @@ public class UserV1ApiE2ETest {
         databaseCleanUp.truncateAllTables();
     }
 
+    private static final String ENDPOINT = "/api/v1/users";
+
     @DisplayName("POST /api/v1/users")
     @Nested
     class Register {
 
-        private static final String ENDPOINT = "/api/v1/users";
 
         @DisplayName("회원 가입이 성공한 경우, 생성된 유저 정보를 응답으로 반환한다.")
         @Test
         void returnUserInfo_whenRegisterIsSuccessful() {
             // arrange
             UserV1Dto.RegisterUserRequest request = new UserV1Dto.RegisterUserRequest(
-              "test123",
-              "test@test.com",
-              "1999-01-01",
-              "M"
+                    "test123",
+                    "test@test.com",
+                    "1999-01-01",
+                    "M"
             );
 
             // act
@@ -97,7 +90,7 @@ public class UserV1ApiE2ETest {
 
             // act
             ParameterizedTypeReference<ApiResponse<UserV1Dto.UsersResponse>> responseType =
-            new ParameterizedTypeReference<>() {};
+                    new ParameterizedTypeReference<>() {};
             ResponseEntity<ApiResponse<UserV1Dto.UsersResponse>> response =
                     testRestTemplate.exchange(
                             ENDPOINT,
@@ -115,6 +108,72 @@ public class UserV1ApiE2ETest {
 
     }
 
+    @DisplayName("GET /api/v1/users/me")
+    @Nested
+    class GetUser {
+
+        @DisplayName("내 정보 조회에 성공할 경우, 해당하는 유저 정보를 응답으로 반환한다.")
+        @Test
+        void returnUserInfo_whenGetUserIsSuccessful() {
+
+            // arrange
+            String requestUrl = ENDPOINT + "/me";
+            UserModel savedUser = userJpaRepository.save(
+                    new UserModel("test123", "test@test.com", "1999-01-01", "M")
+            );
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.add("X-USER-ID", savedUser.getLoginId());
+            HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+            // act
+            ParameterizedTypeReference<ApiResponse<UserV1Dto.UsersResponse>> responseType =
+                    new ParameterizedTypeReference<>() {};
+            ResponseEntity<ApiResponse<UserV1Dto.UsersResponse>> response =
+                    testRestTemplate.exchange(
+                            requestUrl,
+                            HttpMethod.GET,
+                            entity,
+                            responseType
+                    );
+            // assert
+            assertAll(
+                    () -> assertThat(response.getBody().data().email()).isEqualTo(savedUser.getEmail()),
+                    () -> assertThat(response.getBody().data().birth()).isEqualTo(savedUser.getBirth()),
+                    () -> assertThat(response.getBody().data().gender()).isEqualTo(savedUser.getGender())
+            );
+        }
+
+        @DisplayName("존재하지 않는 ID 로 조회할 경우, `404 Not Found` 응답을 반환한다.")
+        @Test
+        void throwException_whenGetUserByLoginIdIsNotFound() {
+            String requestUrl = ENDPOINT + "/me";
+
+            // arrange
+            userJpaRepository.save(
+                    new UserModel("test123", "test@test.com", "1999-01-01", "M")
+            );
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.add("X-USER-ID", "11122");
+            HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+            // act
+            ParameterizedTypeReference<ApiResponse<UserV1Dto.UsersResponse>> responseType =
+                    new ParameterizedTypeReference<>() {};
+            ResponseEntity<ApiResponse<UserV1Dto.UsersResponse>> response =
+                    testRestTemplate.exchange(
+                            requestUrl,
+                            HttpMethod.GET,
+                            entity,
+                            responseType
+                    );
+
+            // assert
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        }
+
+    }
 
 
 }

--- a/apps/commerce-api/src/test/java/com/loopers/interfaces/api/user/UserV1ApiE2ETest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/interfaces/api/user/UserV1ApiE2ETest.java
@@ -1,0 +1,120 @@
+package com.loopers.interfaces.api.user;
+
+import com.loopers.domain.user.UserModel;
+import com.loopers.domain.user.UserService;
+import com.loopers.infrastructure.user.UserJpaRepository;
+import com.loopers.interfaces.api.ApiResponse;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class UserV1ApiE2ETest {
+
+    /*
+    *** E2E 테스트**
+    - [o]  회원 가입이 성공할 경우, 생성된 유저 정보를 응답으로 반환한다.
+    - [ ]  회원 가입 시에 성별이 없을 경우, `400 Bad Request` 응답을 반환한다.
+    *
+    * */
+
+
+    @Autowired
+    private TestRestTemplate testRestTemplate ;
+
+    @Autowired
+    private UserJpaRepository userJpaRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+
+    @AfterEach
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
+
+    @DisplayName("POST /api/v1/users")
+    @Nested
+    class Register {
+
+        private static final String ENDPOINT = "/api/v1/users";
+
+        @DisplayName("회원 가입이 성공한 경우, 생성된 유저 정보를 응답으로 반환한다.")
+        @Test
+        void returnUserInfo_whenRegisterIsSuccessful() {
+            // arrange
+            UserV1Dto.RegisterUserRequest request = new UserV1Dto.RegisterUserRequest(
+              "test123",
+              "test@test.com",
+              "1999-01-01",
+              "M"
+            );
+
+            // act
+            ParameterizedTypeReference<ApiResponse<UserV1Dto.UsersResponse>> responseType =
+                    new ParameterizedTypeReference<ApiResponse<UserV1Dto.UsersResponse>>() {};
+            ResponseEntity<ApiResponse<UserV1Dto.UsersResponse>> response =
+                    testRestTemplate.exchange(
+                            ENDPOINT,
+                            HttpMethod.POST,
+                            new HttpEntity<>(request),
+                            responseType
+                    );
+            // assert
+            assertAll(
+                    () -> assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK),
+                    () -> assertThat(response.getBody()).isNotNull(),
+                    () -> assertThat(response.getBody().data().email()).isEqualTo(request.email())
+            );
+
+        }
+
+
+        @DisplayName("회원 가입 시에 성별이 없을 경우, `400 Bad Request` 응답을 반환한다.")
+        @Test
+        void throwException_whenGenderIsMissing() {
+            // arrange
+            UserV1Dto.RegisterUserRequest request = new UserV1Dto.RegisterUserRequest(
+                    "test1234",
+                    "test@test.com",
+                    "1999-01-01",
+                    ""
+            );
+
+            // act
+            ParameterizedTypeReference<ApiResponse<UserV1Dto.UsersResponse>> responseType =
+            new ParameterizedTypeReference<>() {};
+            ResponseEntity<ApiResponse<UserV1Dto.UsersResponse>> response =
+                    testRestTemplate.exchange(
+                            ENDPOINT,
+                            HttpMethod.POST,
+                            new HttpEntity<>(request),
+                            responseType
+                    );
+
+
+            // assert
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        }
+
+
+
+    }
+
+
+
+}


### PR DESCRIPTION
## 📌 Summary

- 유저와 포인트 관련 API에 대한 단위/통합/E2E 테스트 작성 및 개선
- E2E 테스트에서 X-USER-ID 헤더 처리 방식, RequestBody 구성 방식, 예외 발생 흐름 점검
- Controller → Facade → Service → Model 계층 흐름을 따라 예외 및 성공 케이스 검증

## 💬 Review Points

>  리뷰어가 중점적으로 봐줬으면 하는 부분
 

- amount 증가 로직을 PointModel 내부 도메인 메서드(chargePoint)에서 처리하고 있는데, 이런 연산은 도메인에서 책임지는 게 맞을지, 아니면 서비스 계층에서 처리하는 게 더 적절할까요?
- 현재는 예외 발생 시 CoreException을 퍼사드에서도 던지고, 서비스에서도 던지게 해놨는데, 예외처리를 퍼사드에 몰아주는게 좋은지, 서비스 계층에 분산하는게 좋은지 의견이 궁금합니다.

## ✅ Checklist
### 회원 가입

**🧱 단위 테스트**

- [x]  ID 가 `영문 및 숫자 10자 이내` 형식에 맞지 않으면, User 객체 생성에 실패한다.
- [x]  이메일이 `xx@yy.zz` 형식에 맞지 않으면, User 객체 생성에 실패한다.
- [x]  생년월일이 `yyyy-MM-dd` 형식에 맞지 않으면, User 객체 생성에 실패한다.

**🔗 통합 테스트**

- [x]  회원 가입시 User 저장이 수행된다. ( spy 검증 )
- [x]  이미 가입된 ID 로 회원가입 시도 시, 실패한다.

**🌐 E2E 테스트**

- [x]  회원 가입이 성공할 경우, 생성된 유저 정보를 응답으로 반환한다.
- [x]  회원 가입 시에 성별이 없을 경우, `400 Bad Request` 응답을 반환한다.

### 내 정보 조회

**🔗 통합 테스트**

- [x]  해당 ID 의 회원이 존재할 경우, 회원 정보가 반환된다.
- [x]  해당 ID 의 회원이 존재하지 않을 경우, null 이 반환된다.

**🌐 E2E 테스트**

- [x]  내 정보 조회에 성공할 경우, 해당하는 유저 정보를 응답으로 반환한다.
- [x]  존재하지 않는 ID 로 조회할 경우, `404 Not Found` 응답을 반환한다.

### 포인트 조회

**🔗 통합 테스트**

- [x]  해당 ID 의 회원이 존재할 경우, 보유 포인트가 반환된다.
- [x]  해당 ID 의 회원이 존재하지 않을 경우, null 이 반환된다.

**🌐 E2E 테스트**

- [x]  포인트 조회에 성공할 경우, 보유 포인트를 응답으로 반환한다.
- [x]  `X-USER-ID` 헤더가 없을 경우, `400 Bad Request` 응답을 반환한다.

### 포인트 충전

**🧱 단위 테스트**

- [x]  0 이하의 정수로 포인트를 충전 시 실패한다.

**🔗 통합 테스트**

- [x]  존재하지 않는 유저 ID 로 충전을 시도한 경우, 실패한다.

**🌐 E2E 테스트**

- [x]  존재하는 유저가 1000원을 충전할 경우, 충전된 보유 총량을 응답으로 반환한다.
- [x]  존재하지 않는 유저로 요청할 경우, `404 Not Found` 응답을 반환한다.

