### PR TITLE
Feature/week4/concurrency transaction

### DIFF
--- a/apps/commerce-api/src/main/java/com/loopers/application/coupon/CouponFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/coupon/CouponFacade.java
@@ -1,0 +1,55 @@
+package com.loopers.application.coupon;
+
+import com.loopers.domain.coupon.CouponModel;
+import com.loopers.domain.coupon.CouponService;
+import com.loopers.domain.userCoupon.UserCouponModel;
+import com.loopers.domain.order.OrderItemModel;
+import com.loopers.domain.user.UserModel;
+import com.loopers.domain.userCoupon.UserCouponService;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Component
+public class CouponFacade {
+    private final CouponService couponService;
+    private final UserCouponService userCouponService;
+
+    public void applyCoupon(UserModel user, List<OrderItemModel> orderItems, UserCouponModel userCouponModel) {
+        // 1. 유저 쿠폰 조회
+        UserCouponModel userCoupon = userCouponService.getUserCoupon(userCouponModel);
+
+        // 2. 유저 검증
+        userCoupon.validateOwner(user);
+
+        // 3. 사용 여부 확인
+        userCoupon.use();
+
+        // 4. 쿠폰 조회
+        CouponModel coupon = couponService.getCouponbyCouponId(userCoupon.getCouponId());
+        // 5. 할인 대상 여부 확인 (상품ID or 브랜드ID 일치) -- todo. orderItme(productId -> targetId로 변경)
+//        boolean isApplicable = orderItems.stream().anyMatch(item ->
+//                switch (coupon.getTargetType()) {
+//                    case PRODUCT -> coupon.getTargetId().equals(item.getProductId());
+//                    case BRAND -> coupon.getTargetId().equals(item.getBrandId());
+//                });
+
+        orderItems.stream()
+                .filter(item -> coupon.getTargetId().equals(item.getProductId()))
+                .findAny()
+                .orElseThrow(() -> new CoreException(ErrorType.BAD_REQUEST, "쿠폰을 적용할 수 있는 상품이 없습니다."));
+
+        // 6. 총 주문금액 계산
+//        long totalPrice = orderItems.stream().mapToLong(OrderItemModel::getPrice).sum();
+//
+//        // 7. 할인 금액 계산
+//        long discountPrice = coupon.calculateDiscount(totalPrice);
+//
+//        // 8. 결과 생성
+//        return UserCouponInfo.from(userCoupon, coupon, discountPrice);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/coupon/CouponFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/coupon/CouponFacade.java
@@ -19,9 +19,9 @@ public class CouponFacade {
     private final CouponService couponService;
     private final UserCouponService userCouponService;
 
-    public void applyCoupon(UserModel user, List<OrderItemModel> orderItems, UserCouponModel userCouponModel) {
+    public void applyCoupon(UserModel user, List<OrderItemModel> orderItems, String userCouponId) {
         // 1. 유저 쿠폰 조회
-        UserCouponModel userCoupon = userCouponService.getUserCoupon(userCouponModel);
+        UserCouponModel userCoupon = userCouponService.getUserCoupon(userCouponId);
 
         // 2. 유저 검증
         userCoupon.validateOwner(user);

--- a/apps/commerce-api/src/main/java/com/loopers/application/coupon/UserCouponInfo.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/coupon/UserCouponInfo.java
@@ -1,0 +1,29 @@
+package com.loopers.application.coupon;
+
+import com.loopers.domain.coupon.CouponModel;
+import com.loopers.domain.userCoupon.UserCouponModel;
+
+public record UserCouponInfo(
+            String userCouponId,
+            String couponId,
+            CouponModel.CouponType couponType,
+            CouponModel.TargetType targetType,
+            String targetId,
+            Long discountPrice,
+            Long discountAmount,
+            Double discountRate
+    ) {
+        public static UserCouponInfo from(UserCouponModel userCoupon, CouponModel coupon, Long discountPrice) {
+            return new UserCouponInfo(
+                    userCoupon.getUserCouponId(),
+                    coupon.getCouponId(),
+                    coupon.getCouponType(),
+                    coupon.getTargetType(),
+                    coupon.getTargetId(),
+                    discountPrice,
+                    coupon.getDiscountAmount(),
+                    coupon.getDiscountRate()
+            );
+        }
+
+}

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
@@ -30,7 +30,7 @@ public class OrderFacade {
     private final CouponFacade couponFacade;
 
     @Transactional
-    public OrderInfo createOrderFromCart(UserModel user, UserCouponModel usercoupon) { // userCouponModel ㅍ람추가예정
+    public OrderInfo createOrderFromCart(UserModel user, String userCouponId) { // userCouponModel ㅍ람추가예정
         // 1. 유저 장바구니 조회
         CartModel cart = cartService.getOrCreateCart(user);
         List<CartItemModel> cartItems = cartService.getAllCart(cart);
@@ -46,32 +46,27 @@ public class OrderFacade {
         orderItems.forEach(item -> item.assignOrderId(order.getOrderId()));
 
         // 쿠폰 차감
-        couponFacade.applyCoupon(user, orderItems, usercoupon);
+        couponFacade.applyCoupon(user, orderItems, userCouponId);
         
         // 4. 포인트 차감
         pointService.usePoint(user.getLoginId(), order.getTotalPrice());
 
 
         // 5. product 재고 차감
-        for (OrderItemModel item : orderItems) {
-            ProductModel product = productService.getProductByProductId(item.getProductId())
-                    .orElseThrow(()-> new CoreException(ErrorType.BAD_REQUEST, "상품이 존재하지 않습니다."));
-            product.decreaseStock(item.getQuantity());
-            productService.saveProduct(product);
-        }
+        productService.decreaseProductStock(orderItems);
 
         // 6. 주문 저장
         orderService.saveOrder(order);
         orderService.saveOrderItems(orderItems);
 
-        // 7. 카트 비우기
-        cartService.clearCart(cart);
 
-        // 8. 주문 정보 반환
+        // 7. 주문 정보 반환
         List<OrderItemInfo> orderItemInfos = orderItems.stream()
                 .map(OrderItemInfo::from)
                 .toList();
 
+        // 8. 카트 비우기
+        cartService.clearCart(cart);
         return OrderInfo.from(order, orderItemInfos);
 
     }

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
@@ -1,5 +1,6 @@
 package com.loopers.application.order;
 
+import com.loopers.application.coupon.CouponFacade;
 import com.loopers.domain.cart.CartItemModel;
 import com.loopers.domain.cart.CartModel;
 import com.loopers.domain.cart.CartService;
@@ -10,6 +11,7 @@ import com.loopers.domain.point.PointService;
 import com.loopers.domain.product.ProductModel;
 import com.loopers.domain.product.ProductService;
 import com.loopers.domain.user.UserModel;
+import com.loopers.domain.userCoupon.UserCouponModel;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import jakarta.transaction.Transactional;
@@ -25,9 +27,10 @@ public class OrderFacade {
     private final OrderService orderService;
     private final ProductService productService;
     private final PointService pointService;
+    private final CouponFacade couponFacade;
 
     @Transactional
-    public OrderInfo createOrderFromCart(UserModel user) {
+    public OrderInfo createOrderFromCart(UserModel user, UserCouponModel usercoupon) { // userCouponModel ㅍ람추가예정
         // 1. 유저 장바구니 조회
         CartModel cart = cartService.getOrCreateCart(user);
         List<CartItemModel> cartItems = cartService.getAllCart(cart);
@@ -43,6 +46,7 @@ public class OrderFacade {
         orderItems.forEach(item -> item.assignOrderId(order.getOrderId()));
 
         // 쿠폰 차감
+        couponFacade.applyCoupon(user, orderItems, usercoupon);
         
         // 4. 포인트 차감
         pointService.usePoint(user.getLoginId(), order.getTotalPrice());

--- a/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
+++ b/apps/commerce-api/src/main/java/com/loopers/application/order/OrderFacade.java
@@ -66,7 +66,7 @@ public class OrderFacade {
                 .toList();
 
         // 8. 카트 비우기
-        cartService.clearCart(cart);
+//        cartService.clearCart(cart);
         return OrderInfo.from(order, orderItemInfos);
 
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/cart/CartRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/cart/CartRepository.java
@@ -9,10 +9,11 @@ import java.util.Optional;
 public interface CartRepository {
 
     Optional<CartModel> findCartByLoginId(UserModel user);
+    Optional<CartModel> findCartByLoginIdWithLock(UserModel user);
     Optional<CartModel> findCartByCartId(String cartId);
     void saveCart(CartModel cart);
     void clearCart(CartModel cart);
     Optional<CartItemModel> findCartItemByCartIdProductId(CartItemModel cartItem, ProductModel product);
-    List<CartItemModel> findCartItemsByCartId(String cartId);
+    List<CartItemModel> findCartItemsByCartIdWithLock(String cartId);
     void saveCartItem(CartItemModel cartItem);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/cart/CartRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/cart/CartRepository.java
@@ -11,7 +11,7 @@ public interface CartRepository {
     Optional<CartModel> findCartByLoginId(UserModel user);
     Optional<CartModel> findCartByLoginIdWithLock(UserModel user);
     Optional<CartModel> findCartByCartId(String cartId);
-    void saveCart(CartModel cart);
+    CartModel saveCart(CartModel cart);
     void clearCart(CartModel cart);
     Optional<CartItemModel> findCartItemByCartIdProductId(CartItemModel cartItem, ProductModel product);
     List<CartItemModel> findCartItemsByCartIdWithLock(String cartId);

--- a/apps/commerce-api/src/main/java/com/loopers/domain/cart/CartService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/cart/CartService.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.catalina.User;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -20,8 +21,9 @@ public class CartService {
 
     private final CartRepository cartRepository;
 
+    @Transactional
     public CartModel getOrCreateCart(UserModel user) {
-        return cartRepository.findCartByLoginId(user)
+        return cartRepository.findCartByLoginIdWithLock(user)
                 .orElseGet(() -> {
                     CartModel newCart = CartModel.create(user.getLoginId());
                     cartRepository.saveCart(newCart);
@@ -46,8 +48,9 @@ public class CartService {
         cartRepository.saveCart(cart);
     }
 
+    @Transactional
     public List<CartItemModel> getAllCart(CartModel cart) {
-         return Optional.of(cartRepository.findCartItemsByCartId(cart.getCartId()))
+         return Optional.of(cartRepository.findCartItemsByCartIdWithLock(cart.getCartId()))
                  .filter(items -> !items.isEmpty())
                  .orElseThrow(() -> new CoreException(ErrorType.BAD_REQUEST, "장바구니가 비었습니다."));
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponModel.java
@@ -1,0 +1,66 @@
+package com.loopers.domain.coupon;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@Entity
+@Slf4j
+@Getter
+@Table(name = "coupon")
+public class CouponModel {
+    @Id
+    private String couponId;
+    private CouponType couponType;
+    private Long discountAmount;
+    private Double discountRate;
+    private TargetType targetType; // product/ brandId
+    private String targetId;
+    private String createdAt;
+    private String expiredAt; // 만료일자
+
+    protected CouponModel() {}
+
+    public CouponModel(String couponId,
+                       CouponType couponType,
+                       Long discountAmount,
+                       Double discountRate,
+                       TargetType targetType,
+                       String targetId,
+                       String createdAt,
+                       String expiredAt) {
+        if (couponType == CouponType.FIXED && discountAmount == null) {
+            throw new IllegalArgumentException("FIXED 쿠폰은 discountAmount가 필수입니다.");
+        }
+
+        if (couponType == CouponType.PERCENT && discountRate == null) {
+            throw new IllegalArgumentException("PERCENT 쿠폰은 discountRate가 필수입니다.");
+        }
+
+        this.couponId = couponId;
+        this.couponType = couponType;
+        this.discountAmount = discountAmount;
+        this.discountRate = discountRate;
+        this.targetType = targetType;
+        this.targetId = targetId;
+        this.createdAt = createdAt;
+        this.expiredAt = expiredAt;
+    }
+
+    public Long calculateDiscount(Long totalPrice) {
+        return switch (couponType) {
+            case FIXED -> discountAmount;
+            case PERCENT -> Math.round(totalPrice * discountRate);
+        };
+    }
+
+    public enum CouponType {
+        FIXED, PERCENT
+    }
+
+    public enum TargetType {
+        PRODUCT, BRAND
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.domain.coupon;
+
+import java.util.Optional;
+
+public interface CouponRepository {
+    Optional<CouponModel> findCouponByCouponId(String couponId);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponRepository.java
@@ -3,5 +3,5 @@ package com.loopers.domain.coupon;
 import java.util.Optional;
 
 public interface CouponRepository {
-    Optional<CouponModel> findCouponByCouponId(String couponId);
+    Optional<CouponModel> findCouponByCouponIdWithLock(String couponId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponService.java
@@ -1,0 +1,21 @@
+package com.loopers.domain.coupon;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CouponService {
+    private final CouponRepository couponRepository;
+
+    public CouponModel getCouponbyCouponId(String couponId) {
+        return couponRepository.findCouponByCouponId(couponId)
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "쿠폰 정책이 존재하지 않습니다."));
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/coupon/CouponService.java
@@ -1,10 +1,13 @@
 package com.loopers.domain.coupon;
 
+import com.loopers.domain.user.UserModel;
+import com.loopers.domain.userCoupon.UserCouponModel;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -14,8 +17,10 @@ import java.util.Optional;
 public class CouponService {
     private final CouponRepository couponRepository;
 
+    @Transactional
     public CouponModel getCouponbyCouponId(String couponId) {
-        return couponRepository.findCouponByCouponId(couponId)
+        return couponRepository.findCouponByCouponIdWithLock(couponId)
                 .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "쿠폰 정책이 존재하지 않습니다."));
     }
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeModel.java
@@ -3,18 +3,25 @@ package com.loopers.domain.like;
 import com.loopers.domain.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.Version;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 @Entity
 @Slf4j
 @Getter
-@Table(name = "like_table")
+@Table(
+        name = "like_table"
+)
 public class LikeModel extends BaseEntity {
     private String likeId;
     private String productId;
     private String loginId;
     private boolean isLike;
+
+//    @Version
+//    private Long version;
 
     protected LikeModel() {}
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeRepository.java
@@ -11,10 +11,10 @@ public interface LikeRepository {
     Optional<LikeSummaryModel> findLikeCountByProductId(String productId);
     Optional<LikeModel> findByLoginIdAndProductId(String loginId, String productId);
 
-    void saveLike(LikeModel likeModel);
+    LikeModel saveLike(LikeModel likeModel);
     void deleteLike(LikeModel likeModel);
 
-    void saveLikeSummary(LikeSummaryModel likeSummaryModel);
+    LikeSummaryModel saveLikeSummary(LikeSummaryModel likeSummaryModel);
 
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeService.java
@@ -7,6 +7,7 @@ import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,6 +20,7 @@ import java.util.UUID;
 public class LikeService {
     private final LikeRepository likeRepository;
 
+    @Transactional
     public void createLike(String loginId, String productId) {
         Optional<LikeModel> likeModel = likeRepository.findByLoginIdAndProductId(loginId, productId);
 
@@ -30,16 +32,23 @@ public class LikeService {
                     true
             );
             likeRepository.saveLike(like);
-            increaseLikeSummary(productId);
+            LikeSummaryModel summary = likeRepository.findLikeCountByProductId(productId).orElse(null);
+            summary.increase();
+            likeRepository.saveLikeSummary(summary);
+//            increaseLikeSummary(productId);
         } else {
             LikeModel like = likeModel.get();
             if(!like.isLike()){
                 like.like();
-                increaseLikeSummary(productId);
+                LikeSummaryModel summary = likeRepository.findLikeCountByProductId(productId).orElse(null);
+                summary.increase();
+                likeRepository.saveLikeSummary(summary);
+//                increaseLikeSummary(productId);
             }
         }
     }
 
+    @Transactional
     public void deleteLike(String loginId, String productId) {
         Optional<LikeModel> optional = likeRepository.findByLoginIdAndProductId(loginId, productId);
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeSummaryModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/like/LikeSummaryModel.java
@@ -3,17 +3,24 @@ package com.loopers.domain.like;
 import com.loopers.domain.BaseEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.Version;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 @Entity
 @Slf4j
 @Getter
-@Table(name = "like_summary")
+@Table(
+        name = "like_summary"
+)
 public class LikeSummaryModel extends BaseEntity {
     private String productId;
 
     private int totalLikeCount;
+
+//    @Version
+//    private Long version;
 
     protected LikeSummaryModel() {}
 

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointRepository.java
@@ -1,7 +1,13 @@
 package com.loopers.domain.point;
 
+import java.util.Optional;
+
 public interface PointRepository {
 
     PointModel save(PointModel point);
+
     PointModel findPointByLoginId(String loginId);
+
+    Optional<PointModel> findPointByLoginIdWithLock(String loginId);
+
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
@@ -30,12 +30,13 @@ public class PointService {
     }
 
     public PointModel usePoint(String loginId, Long amount) {
-        if (!userRepository.existsByLoginId(loginId)) {
-            throw new CoreException(ErrorType.NOT_FOUND);
-        }
-
-        PointModel pointModel = pointRepository.findPointByLoginId(loginId);
+        PointModel pointModel = pointRepository.findPointByLoginIdWithLock(loginId)
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND));
         pointModel.usePoint(amount);
         return pointRepository.save(pointModel);
+    }
+
+    public void savePoint(PointModel pointModel) {
+        pointRepository.save(pointModel);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/point/PointService.java
@@ -7,6 +7,7 @@ import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -29,6 +30,7 @@ public class PointService {
         return pointRepository.save(pointModel);
     }
 
+    @Transactional
     public PointModel usePoint(String loginId, Long amount) {
         PointModel pointModel = pointRepository.findPointByLoginIdWithLock(loginId)
                 .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND));

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductRepository.java
@@ -1,7 +1,6 @@
 package com.loopers.domain.product;
 
 import com.loopers.application.product.ProductSortCondition;
-
 import java.util.List;
 import java.util.Optional;
 
@@ -10,5 +9,6 @@ public interface ProductRepository {
     List<ProductModel> findAllProducts(ProductSortCondition sortCondition);
     Optional<ProductModel> findProduct(ProductModel product);
     Optional<ProductModel> findProductByProductId(String productId);
+    Optional<ProductModel> findProductByProductIdWithLock(String productId);
     void saveProduct(ProductModel product);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/product/ProductService.java
@@ -2,12 +2,14 @@ package com.loopers.domain.product;
 
 import com.loopers.application.product.ProductSortCondition;
 import com.loopers.domain.brand.BrandModel;
+import com.loopers.domain.order.OrderItemModel;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -20,7 +22,9 @@ public class ProductService {
 
     public List<ProductModel> getAllProducts(ProductSortCondition sortCondition) {
         return productRepository.findAllProducts(sortCondition);
-    };
+    }
+
+    ;
 
     public Optional<ProductModel> getProduct(ProductModel product) {
         return productRepository.findProduct(product);
@@ -28,6 +32,20 @@ public class ProductService {
 
     public Optional<ProductModel> getProductByProductId(String productId) {
         return productRepository.findProductByProductId(productId);
+    }
+
+    public Optional<ProductModel> getProductByProductIdWithLock(String productId) {
+        return productRepository.findProductByProductIdWithLock(productId);
+    }
+
+    @Transactional
+    public void decreaseProductStock(List<OrderItemModel> orderItems) {
+        for (OrderItemModel item : orderItems) {
+            ProductModel product = getProductByProductIdWithLock(item.getProductId())
+                    .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "상품이 존재하지 않습니다."));
+            product.decreaseStock(item.getQuantity());
+            saveProduct(product);
+        }
     }
 
     public void saveProduct(ProductModel product) {

--- a/apps/commerce-api/src/main/java/com/loopers/domain/userCoupon/UserCouponModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/userCoupon/UserCouponModel.java
@@ -1,0 +1,51 @@
+package com.loopers.domain.userCoupon;
+
+import com.loopers.domain.user.UserModel;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@Entity
+@Slf4j
+@Getter
+@Table(name = "user_coupon")
+public class UserCouponModel {
+    @Id
+    private String userCouponId;
+    private String loginId;
+    private String couponId;
+    private boolean used;
+    private String issuedAt; // 사용일자
+
+    protected UserCouponModel() {}
+
+    public UserCouponModel(String userCouponId, String loginId, String couponId, String issuedAt) {
+        this.userCouponId = userCouponId;
+        this.loginId = loginId;
+        this.couponId = couponId;
+        this.used = false;
+        this.issuedAt = issuedAt;
+    }
+
+
+    public void validateOwner(UserModel user) {
+        if (!this.loginId.equals(user.getLoginId())) {
+            throw new CoreException(ErrorType.NOT_FOUND, "본인의 쿠폰이 아닙니다.");
+        }
+    }
+
+    public void validateNotUsed() {
+        if (used && (issuedAt != null || issuedAt != "")) {
+            throw new CoreException(ErrorType.BAD_REQUEST, "이미 사용된 쿠폰입니다.");
+        }
+    }
+
+    public void use() {
+        validateNotUsed();
+        this.used = true;
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/userCoupon/UserCouponModel.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/userCoupon/UserCouponModel.java
@@ -6,6 +6,7 @@ import com.loopers.support.error.ErrorType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -20,6 +21,9 @@ public class UserCouponModel {
     private String couponId;
     private boolean used;
     private String issuedAt; // 사용일자
+
+    @Version
+    private Long version;
 
     protected UserCouponModel() {}
 
@@ -39,7 +43,7 @@ public class UserCouponModel {
     }
 
     public void validateNotUsed() {
-        if (used && (issuedAt != null || issuedAt != "")) {
+        if (used) {
             throw new CoreException(ErrorType.BAD_REQUEST, "이미 사용된 쿠폰입니다.");
         }
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/userCoupon/UserCouponRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/userCoupon/UserCouponRepository.java
@@ -4,5 +4,6 @@ import java.util.Optional;
 
 public interface UserCouponRepository {
 
-    Optional<UserCouponModel> findUserCoupon(String userCouponId);
+    Optional<UserCouponModel> findUserCouponByUserCouponId(String userCouponId);
+    UserCouponModel saveUserCoupon(UserCouponModel userCoupon);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/userCoupon/UserCouponRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/userCoupon/UserCouponRepository.java
@@ -1,0 +1,8 @@
+package com.loopers.domain.userCoupon;
+
+import java.util.Optional;
+
+public interface UserCouponRepository {
+
+    Optional<UserCouponModel> findUserCoupon(UserCouponModel userCouponModel);
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/userCoupon/UserCouponRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/userCoupon/UserCouponRepository.java
@@ -4,5 +4,5 @@ import java.util.Optional;
 
 public interface UserCouponRepository {
 
-    Optional<UserCouponModel> findUserCoupon(UserCouponModel userCouponModel);
+    Optional<UserCouponModel> findUserCoupon(String userCouponId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/userCoupon/UserCouponService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/userCoupon/UserCouponService.java
@@ -1,0 +1,22 @@
+package com.loopers.domain.userCoupon;
+
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class UserCouponService {
+    private final UserCouponRepository userCouponRepository;
+
+    public UserCouponModel getUserCoupon(UserCouponModel userCouponModel) {
+        return userCouponRepository.findUserCoupon(userCouponModel)
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "사용자의 쿠폰이 존재하지 않습니다."));
+
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/domain/userCoupon/UserCouponService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/userCoupon/UserCouponService.java
@@ -14,8 +14,8 @@ import java.util.Optional;
 public class UserCouponService {
     private final UserCouponRepository userCouponRepository;
 
-    public UserCouponModel getUserCoupon(UserCouponModel userCouponModel) {
-        return userCouponRepository.findUserCoupon(userCouponModel)
+    public UserCouponModel getUserCoupon(String userCouponId) {
+        return userCouponRepository.findUserCoupon(userCouponId)
                 .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "사용자의 쿠폰이 존재하지 않습니다."));
 
     }

--- a/apps/commerce-api/src/main/java/com/loopers/domain/userCoupon/UserCouponService.java
+++ b/apps/commerce-api/src/main/java/com/loopers/domain/userCoupon/UserCouponService.java
@@ -1,10 +1,12 @@
 package com.loopers.domain.userCoupon;
 
+import com.loopers.domain.user.UserModel;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -14,9 +16,20 @@ import java.util.Optional;
 public class UserCouponService {
     private final UserCouponRepository userCouponRepository;
 
-    public UserCouponModel getUserCoupon(String userCouponId) {
-        return userCouponRepository.findUserCoupon(userCouponId)
-                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "사용자의 쿠폰이 존재하지 않습니다."));
+    @Transactional
+    public UserCouponModel getUserCouponByUserCouponId(String userCouponId) {
+        return userCouponRepository.findUserCouponByUserCouponId(userCouponId)
+                .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND, "이미 사용된 쿠폰입니다."));
 
+    }
+
+    @Transactional
+    public UserCouponModel useCoupon(UserModel user, String userCouponId) {
+        UserCouponModel userCoupon = getUserCouponByUserCouponId(userCouponId);
+
+        userCoupon.validateOwner(user);
+        userCoupon.use();
+
+        return userCouponRepository.saveUserCoupon(userCoupon);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/cart/CartItemJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/cart/CartItemJpaRepository.java
@@ -2,7 +2,10 @@ package com.loopers.infrastructure.cart;
 
 import com.loopers.domain.cart.CartItemModel;
 import com.loopers.domain.cart.CartModel;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,7 +13,9 @@ import java.util.Optional;
 public interface CartItemJpaRepository extends JpaRepository<CartItemModel, String> {
 
     Optional<CartItemModel> findByCartIdAndProductId(String cartId, String productId);
-    List<CartItemModel> findCartItemsByCartId(String cartId);
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM CartItemModel p WHERE p.cartId = :cartId")
+    List<CartItemModel> findCartItemsByCartIdWithLock(String cartId);
 
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/cart/CartJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/cart/CartJpaRepository.java
@@ -1,13 +1,20 @@
 package com.loopers.infrastructure.cart;
 
 import com.loopers.domain.cart.CartModel;
+import com.loopers.domain.cart.CartRepository;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface CartJpaRepository extends JpaRepository<CartModel, String> {
 
     Optional<CartModel> findCartByLoginId(String loginId);
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM CartModel p  WHERE p.loginId = :loginId")
+    Optional<CartModel> findCartByLoginIdWithLock(String loginId);
     Optional<CartModel> findCartByCartId(String cartId);
     int findTotalQuantityByCartId(String cartId);
     int findTotalPriceByCartId(String cartId);

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/cart/CartRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/cart/CartRepositoryImpl.java
@@ -23,6 +23,11 @@ public class CartRepositoryImpl implements CartRepository {
     }
 
     @Override
+    public Optional<CartModel> findCartByLoginIdWithLock(UserModel user) {
+        return cartJpaRepository.findCartByLoginIdWithLock(user.getLoginId());
+    }
+
+    @Override
     public Optional<CartModel> findCartByCartId(String cartId) {
         return cartJpaRepository.findCartByCartId(cartId);
     }
@@ -51,8 +56,8 @@ public class CartRepositoryImpl implements CartRepository {
     }
 
     @Override
-    public List<CartItemModel> findCartItemsByCartId(String cartId) {
-        return cartItemJpaRepository.findCartItemsByCartId(cartId);
+    public List<CartItemModel> findCartItemsByCartIdWithLock(String cartId) {
+        return cartItemJpaRepository.findCartItemsByCartIdWithLock(cartId);
     }
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/cart/CartRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/cart/CartRepositoryImpl.java
@@ -34,8 +34,8 @@ public class CartRepositoryImpl implements CartRepository {
 
 
     @Override
-    public void saveCart(CartModel cart) {
-        cartJpaRepository.save(cart);
+    public CartModel saveCart(CartModel cart) {
+        return cartJpaRepository.save(cart);
     }
 
     @Override

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponJpaRepository.java
@@ -1,7 +1,15 @@
 package com.loopers.infrastructure.coupon;
 
 import com.loopers.domain.coupon.CouponModel;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface CouponJpaRepository extends JpaRepository<CouponModel, String> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM CouponModel p WHERE p.couponId = :couponId")
+    Optional<CouponModel> findCouponByCouponIdWithLock(String couponId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponJpaRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.infrastructure.coupon;
+
+import com.loopers.domain.coupon.CouponModel;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CouponJpaRepository extends JpaRepository<CouponModel, String> {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponRepositoryImpl.java
@@ -13,7 +13,7 @@ public class CouponRepositoryImpl implements CouponRepository {
     private final CouponJpaRepository couponJpaRepository;
 
     @Override
-    public Optional<CouponModel> findCouponByCouponId(String couponId) {
-        return couponJpaRepository.findById(couponId);
+    public Optional<CouponModel> findCouponByCouponIdWithLock(String couponId) {
+        return couponJpaRepository.findCouponByCouponIdWithLock(couponId);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/coupon/CouponRepositoryImpl.java
@@ -1,0 +1,19 @@
+package com.loopers.infrastructure.coupon;
+
+import com.loopers.domain.coupon.CouponModel;
+import com.loopers.domain.coupon.CouponRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Component
+public class CouponRepositoryImpl implements CouponRepository {
+    private final CouponJpaRepository couponJpaRepository;
+
+    @Override
+    public Optional<CouponModel> findCouponByCouponId(String couponId) {
+        return couponJpaRepository.findById(couponId);
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/like/LikeRepositoryImpl.java
@@ -32,8 +32,8 @@ public class LikeRepositoryImpl implements LikeRepository {
     }
 
     @Override
-    public void saveLike(LikeModel likeModel) {
-        likeJpaRepository.save(likeModel);
+    public LikeModel saveLike(LikeModel likeModel) {
+       return likeJpaRepository.save(likeModel);
     }
 
     @Override
@@ -42,8 +42,8 @@ public class LikeRepositoryImpl implements LikeRepository {
     }
 
     @Override
-    public void saveLikeSummary(LikeSummaryModel likeSummaryModel) {
-        likeSummaryJpaRepository.save(likeSummaryModel);
+    public LikeSummaryModel saveLikeSummary(LikeSummaryModel likeSummaryModel) {
+        return likeSummaryJpaRepository.save(likeSummaryModel);
     }
 
 

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointJpaRepository.java
@@ -1,12 +1,21 @@
 package com.loopers.infrastructure.point;
 
 import com.loopers.domain.point.PointModel;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface PointJpaRepository extends JpaRepository<PointModel, Long> {
 
     Optional<PointModel> findPointByLoginId(String loginId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM PointModel p WHERE p.loginId = :loginId")
+    Optional<PointModel> findByLoginIdWithLock(@Param("loginId") String loginId);
+
 
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/point/PointRepositoryImpl.java
@@ -5,6 +5,8 @@ import com.loopers.domain.point.PointRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.Optional;
+
 @RequiredArgsConstructor
 @Component
 public class PointRepositoryImpl implements PointRepository {
@@ -19,5 +21,10 @@ public class PointRepositoryImpl implements PointRepository {
     public PointModel findPointByLoginId(String loginId) {
         return pointJpaRepository.findPointByLoginId(loginId)
                 .orElse(null);
+    }
+
+    @Override
+    public Optional<PointModel> findPointByLoginIdWithLock(String loginId) {
+        return pointJpaRepository.findByLoginIdWithLock(loginId);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductJpaRepository.java
@@ -1,11 +1,18 @@
 package com.loopers.infrastructure.product;
 
 import com.loopers.domain.product.ProductModel;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface ProductJpaRepository extends JpaRepository<ProductModel, String> {
 
     Optional<ProductModel> findProductByProductId(String productId);
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM ProductModel p WHERE p.productId = :productId")
+    Optional<ProductModel> findProductByProductIdWithLock(@Param("productId") String productId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/product/ProductRepositoryImpl.java
@@ -35,6 +35,11 @@ public class ProductRepositoryImpl implements ProductRepository {
     }
 
     @Override
+    public Optional<ProductModel> findProductByProductIdWithLock(String productId) {
+        return productJpaRepository.findProductByProductIdWithLock(productId);
+    }
+
+    @Override
     public void saveProduct(ProductModel product) {
         productJpaRepository.save(product);
     }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/userCoupon/UserCouponJapRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/userCoupon/UserCouponJapRepository.java
@@ -1,0 +1,7 @@
+package com.loopers.infrastructure.userCoupon;
+
+import com.loopers.domain.userCoupon.UserCouponModel;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserCouponJapRepository extends JpaRepository<UserCouponModel, String> {
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/userCoupon/UserCouponJapRepository.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/userCoupon/UserCouponJapRepository.java
@@ -1,7 +1,13 @@
 package com.loopers.infrastructure.userCoupon;
 
 import com.loopers.domain.userCoupon.UserCouponModel;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface UserCouponJapRepository extends JpaRepository<UserCouponModel, String> {
+    Optional<UserCouponModel> findUserCouponByUserCouponId(String userCouponId);
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/userCoupon/UserCouponRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/userCoupon/UserCouponRepositoryImpl.java
@@ -13,7 +13,12 @@ import java.util.Optional;
 public class UserCouponRepositoryImpl implements UserCouponRepository {
     private final UserCouponJapRepository userCouponjpaRepository;
     @Override
-    public Optional<UserCouponModel> findUserCoupon(String userCouponId) {
-        return userCouponjpaRepository.findById(userCouponId);
+    public Optional<UserCouponModel> findUserCouponByUserCouponId(String userCouponId) {
+        return userCouponjpaRepository.findUserCouponByUserCouponId(userCouponId);
+    }
+
+    @Override
+    public UserCouponModel saveUserCoupon(UserCouponModel userCoupon) {
+        return userCouponjpaRepository.save(userCoupon);
     }
 }

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/userCoupon/UserCouponRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/userCoupon/UserCouponRepositoryImpl.java
@@ -1,0 +1,19 @@
+package com.loopers.infrastructure.userCoupon;
+
+
+import com.loopers.domain.userCoupon.UserCouponModel;
+import com.loopers.domain.userCoupon.UserCouponRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Component
+public class UserCouponRepositoryImpl implements UserCouponRepository {
+    private final UserCouponJapRepository userCouponjpaRepository;
+    @Override
+    public Optional<UserCouponModel> findUserCoupon(UserCouponModel userCouponModel) {
+        return userCouponjpaRepository.findById(userCouponModel.getCouponId());
+    }
+}

--- a/apps/commerce-api/src/main/java/com/loopers/infrastructure/userCoupon/UserCouponRepositoryImpl.java
+++ b/apps/commerce-api/src/main/java/com/loopers/infrastructure/userCoupon/UserCouponRepositoryImpl.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 public class UserCouponRepositoryImpl implements UserCouponRepository {
     private final UserCouponJapRepository userCouponjpaRepository;
     @Override
-    public Optional<UserCouponModel> findUserCoupon(UserCouponModel userCouponModel) {
-        return userCouponjpaRepository.findById(userCouponModel.getCouponId());
+    public Optional<UserCouponModel> findUserCoupon(String userCouponId) {
+        return userCouponjpaRepository.findById(userCouponId);
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/CouponModelTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/CouponModelTest.java
@@ -1,0 +1,64 @@
+package com.loopers.domain;
+
+import com.loopers.domain.coupon.CouponModel;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static com.loopers.domain.coupon.CouponModel.CouponType.FIXED;
+import static com.loopers.domain.coupon.CouponModel.CouponType.PERCENT;
+import static com.loopers.domain.coupon.CouponModel.TargetType.PRODUCT;
+import static org.junit.Assert.assertEquals;
+
+public class CouponModelTest {
+
+    @DisplayName("쿠폰할인을 계산할 때,")
+    @Nested
+    class CalculateDiscount {
+
+        @Test
+        @DisplayName("정액 쿠폰일 경우, 고정된 할인 금액을 반환한다.")
+        void returnFixedAmount_whenFixedCoupon(){
+                // arrange
+                CouponModel coupon = new CouponModel(
+                        "coupon001",
+                        FIXED,
+                        5000L,
+                        null,
+                        PRODUCT,
+                        "product001",
+                        "2025-01-01",
+                        "2025-12-31"
+                );
+
+                // act
+                Long discount = coupon.calculateDiscount(30000L);
+
+                // assert
+                assertEquals(Long.valueOf(5000L) , discount);
+
+        }
+        @Test
+        @DisplayName("정률 쿠폰일 경우, 총 금액의 할인율만큼 할인된다")
+        void returnPercentAmount_whenPercentCoupon() {
+            // arrange
+            CouponModel coupon = new CouponModel(
+                    "coupon002",
+                    PERCENT,
+                    null,
+                    0.1, // 10%
+                    PRODUCT,
+                    "product001",
+                    "2025-01-01",
+                    "2025-12-31"
+            );
+
+            // act
+            Long discount = coupon.calculateDiscount(10000L); // 기대: 1000
+
+            // assert
+            assertEquals(Long.valueOf(1000L), discount);
+        }
+
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponServiceTest.java
@@ -1,0 +1,88 @@
+package com.loopers.domain.coupon;
+
+import com.loopers.domain.order.OrderItemModel;
+import com.loopers.infrastructure.coupon.CouponJpaRepository;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import com.loopers.utils.DatabaseCleanUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.Assert.assertThrows;
+
+@SpringBootTest
+public class CouponServiceTest {
+
+    @Autowired
+    private CouponService couponService;
+
+    @Autowired
+    private CouponJpaRepository couponJpaRepository;
+
+    @Autowired
+    private DatabaseCleanUp databaseCleanUp;
+
+    @AfterEach
+    public void tearDown() { databaseCleanUp.truncateAllTables(); }
+
+    @DisplayName("쿠폰을 조회할 때,")
+    @Nested
+    class GetCoupon{
+        @DisplayName("사용자의 쿠폰이 주문 쿠폰 대상 상품에 포함되지 않은 경우, 예외를 던진다.")
+        @Test
+        void returnErrorCode_whenCouponTargetProductDoesNotExistInOrderItems(){
+            CouponModel coupon = new CouponModel(
+                    "coupon-001",
+                    CouponModel.CouponType.FIXED,
+                    1000L,
+                    null,
+                    CouponModel.TargetType.PRODUCT,
+                    "product-123",
+                    "2025-01-01",
+                    "2025-12-31"
+            );
+
+
+            List<OrderItemModel> orderItems = List.of(
+                    new OrderItemModel("item1", "order1", "otherProduct", 1L, 10000L)
+            );
+
+            // act & assert
+            CoreException exception = assertThrows(CoreException.class, () -> {
+                orderItems.stream()
+                        .filter(item -> coupon.getTargetId().equals(item.getProductId()))
+                        .findAny()
+                        .orElseThrow(() -> new CoreException(ErrorType.BAD_REQUEST, "쿠폰을 적용할 수 있는 상품이 없습니다."));
+            });
+
+            assertThat(exception.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+
+        }
+    }
+
+    @DisplayName("쿠폰이 존재하지 않는 쿠폰일 경우, 예외를 던진다")
+    @Test
+    void returnErrorCode_whenCouponIsNotExist(){
+
+        //arrange
+        String couponId = "coupon-001";
+
+        // act
+        CoreException exception = assertThrows(CoreException.class, () -> {
+            couponService.getCouponbyCouponId(couponId);
+        });
+
+        // assert
+        assertThat(exception.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
+
+
+    }
+
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/coupon/CouponServiceTest.java
@@ -1,19 +1,28 @@
 package com.loopers.domain.coupon;
 
+import com.loopers.application.coupon.CouponFacade;
 import com.loopers.domain.order.OrderItemModel;
+import com.loopers.domain.user.UserModel;
+import com.loopers.domain.userCoupon.UserCouponModel;
+import com.loopers.domain.userCoupon.UserCouponService;
 import com.loopers.infrastructure.coupon.CouponJpaRepository;
+import com.loopers.infrastructure.user.UserJpaRepository;
+import com.loopers.infrastructure.userCoupon.UserCouponJapRepository;
 import com.loopers.support.error.CoreException;
 import com.loopers.support.error.ErrorType;
 import com.loopers.utils.DatabaseCleanUp;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.loopers.domain.coupon.CouponModel.CouponType.FIXED;
+import static com.loopers.domain.coupon.CouponModel.TargetType.PRODUCT;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.Assert.assertThrows;
 
@@ -21,10 +30,19 @@ import static org.junit.Assert.assertThrows;
 public class CouponServiceTest {
 
     @Autowired
+    private CouponFacade couponFacade;
+
+    @Autowired
     private CouponService couponService;
 
     @Autowired
     private CouponJpaRepository couponJpaRepository;
+
+    @Autowired
+    private UserJpaRepository userJpaRepository;
+
+    @Autowired
+    private UserCouponJapRepository userCouponJapRepository;
 
     @Autowired
     private DatabaseCleanUp databaseCleanUp;
@@ -85,4 +103,7 @@ public class CouponServiceTest {
 
     }
 
+
 }
+
+

--- a/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeServiceInteIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/like/LikeServiceInteIntegrationTest.java
@@ -1,7 +1,12 @@
 package com.loopers.domain.like;
 
+import com.loopers.domain.product.ProductModel;
+import com.loopers.domain.product.ProductService;
+import com.loopers.domain.user.UserModel;
 import com.loopers.infrastructure.like.LikeJpaRepository;
 import com.loopers.infrastructure.like.LikeSummaryJpaRepository;
+import com.loopers.infrastructure.product.ProductJpaRepository;
+import com.loopers.infrastructure.user.UserJpaRepository;
 import com.loopers.utils.DatabaseCleanUp;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
@@ -14,11 +19,20 @@ import org.testcontainers.shaded.org.checkerframework.checker.units.qual.N;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Slf4j
 @SpringBootTest
@@ -28,6 +42,9 @@ public class LikeServiceInteIntegrationTest {
     private LikeService likeService;
 
     @Autowired
+    private ProductService productService;
+
+    @Autowired
     private LikeJpaRepository likeJpaRepository;
 
     @Autowired
@@ -35,6 +52,10 @@ public class LikeServiceInteIntegrationTest {
 
     @Autowired
     private DatabaseCleanUp databaseCleanUp;
+    @Autowired
+    private UserJpaRepository userJpaRepository;
+    @Autowired
+    private ProductJpaRepository productJpaRepository;
 
     @AfterEach
     public void tearDown() { databaseCleanUp.truncateAllTables();}
@@ -44,7 +65,7 @@ public class LikeServiceInteIntegrationTest {
     class GetLikeTotalCount {
         @DisplayName("좋아요가 눌린 상품들을 조회할 경우 , 상품들의 좋아요 전체 카운트가 반환된다.")
         @Test
-        void returnTotalCount_whenGetProductLikeSummaries () {
+        void returnTotalCount_whenGetProductLikeSummaries() {
             //arrange
             LikeSummaryModel likeSummaryModel1 = likeSummaryJpaRepository.save(
                     new LikeSummaryModel(
@@ -76,6 +97,102 @@ public class LikeServiceInteIntegrationTest {
                             tuple("p001", 50000),
                             tuple("p002", 20000)
                     );
+        }
+
+        @DisplayName("동일한 상품에 대해 여러명이 좋아요 등록/취소 요청해도, 상품의 좋아요 개수가 정상 반영된다.")
+        @Test
+        void concurrentLikes_whenIncreaseExactlyOncePerUser() throws InterruptedException {
+            List<UserModel> users = List.of(
+                    new UserModel("user1", "example@text.com",   "2000-01-01", "W"),
+                    new UserModel("user2", "example@text.com",    "2000-01-01", "W"),
+                    new UserModel("user3", "example@text.com",   "2000-01-01", "W"),
+                    new UserModel("user4", "example@text.com",    "2000-01-01", "W"),
+                    new UserModel("user5", "example@text.com",    "2000-01-01", "W")
+            );
+            List<UserModel> savedUsers = users.stream()
+                    .map(userJpaRepository::save)
+                    .toList();
+
+            productService.saveProduct(
+                    new ProductModel(
+                            "p001",
+                            "운동화",
+                            "런닝 운동화",
+                            "b001",
+                            1000L,
+                            5L
+                    )
+            );
+
+            LikeSummaryModel likeSummary = likeSummaryJpaRepository.save(
+                    new LikeSummaryModel(
+                            "p001",
+                            0
+                    )
+            );
+
+
+
+            // act 1: 5명이 동시에 좋아요
+            int threads1 = savedUsers.size();
+            ExecutorService pool1 = Executors.newFixedThreadPool(threads1);
+            CountDownLatch ready1 = new CountDownLatch(threads1);
+            CountDownLatch start1 = new CountDownLatch(1);
+            CountDownLatch done1 = new CountDownLatch(threads1);
+
+            for (UserModel u : savedUsers) {
+                pool1.submit(() -> {
+                    try {
+                        ready1.countDown();
+                        start1.await();
+                        likeService.createLike(u.getLoginId(), "p001");
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        done1.countDown();
+                    }
+                });
+            }
+            if (!ready1.await(5, TimeUnit.SECONDS)) throw new IllegalStateException("Phase1 threads not ready");
+            start1.countDown();
+            done1.await(10, TimeUnit.SECONDS);
+            pool1.shutdownNow();
+
+
+            // then 1: 좋아요 수 = 5
+            likeSummary = likeSummaryJpaRepository.findLikeCountByProductId("p001").orElse(null);
+            int totalCount = likeSummary.getTotalLikeCount();
+            assertThat(totalCount).isEqualTo(5);
+
+            // act 2: 3명이 동시에 싫어요(취소) — user1, user2, user3
+            List<UserModel> toUnlike = savedUsers.subList(0, 3);
+            int threads2 = toUnlike.size();
+            ExecutorService pool2 = Executors.newFixedThreadPool(threads2);
+            CountDownLatch ready2 = new CountDownLatch(threads2);
+            CountDownLatch start2 = new CountDownLatch(1);
+            CountDownLatch done2 = new CountDownLatch(threads2);
+
+            for (UserModel u : toUnlike) {
+                pool2.submit(() -> {
+                    try {
+                        ready2.countDown();
+                        start2.await();
+                        likeService.deleteLike(u.getLoginId(), "p001");
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        done2.countDown();
+                    }
+                });
+            }
+            if (!ready2.await(5, TimeUnit.SECONDS)) throw new IllegalStateException("Phase2 threads not ready");
+            start2.countDown();
+            done2.await(10, TimeUnit.SECONDS);
+            pool2.shutdownNow();
+
+            // then 2: 최종 좋아요 수 = 10 - 3 = 7
+            likeSummary = likeSummaryJpaRepository.findLikeCountByProductId("p001").orElse(null);
+            assertThat(likeSummary.getTotalLikeCount()).isEqualTo(2);
         }
     }
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderFacadeIntegrationTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/order/OrderFacadeIntegrationTest.java
@@ -1,6 +1,8 @@
 package com.loopers.domain.order;
 
+import com.loopers.application.coupon.CouponFacade;
 import com.loopers.application.order.OrderFacade;
+import com.loopers.application.order.OrderInfo;
 import com.loopers.domain.cart.CartItemModel;
 import com.loopers.domain.cart.CartModel;
 import com.loopers.domain.cart.CartService;
@@ -11,6 +13,7 @@ import com.loopers.domain.product.ProductModel;
 import com.loopers.domain.product.ProductService;
 import com.loopers.domain.user.UserModel;
 import com.loopers.domain.userCoupon.UserCouponModel;
+import com.loopers.domain.userCoupon.UserCouponService;
 import com.loopers.infrastructure.cart.CartItemJpaRepository;
 import com.loopers.infrastructure.cart.CartJpaRepository;
 import com.loopers.infrastructure.coupon.CouponJpaRepository;
@@ -21,19 +24,27 @@ import com.loopers.infrastructure.product.ProductJpaRepository;
 import com.loopers.infrastructure.user.UserJpaRepository;
 import com.loopers.infrastructure.userCoupon.UserCouponJapRepository;
 import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
 import com.loopers.utils.DatabaseCleanUp;
+import jakarta.persistence.OptimisticLockException;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.CannotAcquireLockException;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.loopers.domain.coupon.CouponModel.CouponType.FIXED;
 import static com.loopers.domain.coupon.CouponModel.TargetType.PRODUCT;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest
 public class OrderFacadeIntegrationTest {
@@ -54,13 +65,16 @@ public class OrderFacadeIntegrationTest {
     private OrderFacade orderFacade;
 
     @Autowired
+    private CouponFacade couponFacade;
+
+    @Autowired
     private PointJpaRepository pointJpaRepository;
 
     @Autowired
     private CartJpaRepository cartJpaRepository;
 
     @Autowired
-    private CartItemJpaRepository  cartItemJpaRepository;
+    private CartItemJpaRepository cartItemJpaRepository;
 
     @Autowired
     private OrderJpaRepository orderJpaRepository;
@@ -79,16 +93,20 @@ public class OrderFacadeIntegrationTest {
     private CouponJpaRepository couponJpaRepository;
     @Autowired
     private UserCouponJapRepository userCouponJapRepository;
+    @Autowired
+    private UserCouponService userCouponService;
 
     @AfterEach
-    void tearDown() { databaseCleanUp.truncateAllTables(); }
+    void tearDown() {
+        databaseCleanUp.truncateAllTables();
+    }
 
     @DisplayName("사용자가 주문할 때,")
     @Nested
     class CreateOrder {
         @DisplayName("포인트 차감, 재고 차감 후 주문 저장하여 주문정보를 반환한다.")
         @Test
-        void returnOrderInfo_whenCartToOrder(){
+        void returnOrderInfo_whenCartToOrder() {
 
             //Assert
             String loginId = "user123";
@@ -137,10 +155,10 @@ public class OrderFacadeIntegrationTest {
 
 
             // Assert
-            Assertions.assertEquals(1, orderJpaRepository.findAll().size());
-            Assertions.assertEquals(1, orderItemJpaRepository.findAll().size());
-            Assertions.assertEquals(10000L - price * quantity, pointService.getPointModelByLoginId(loginId).getAmount());
-            Assertions.assertEquals(8L, productService.getProductByProductId(productId).get().getStock());
+            assertEquals(1, orderJpaRepository.findAll().size());
+            assertEquals(1, orderItemJpaRepository.findAll().size());
+            assertEquals(10000L - price * quantity, pointService.getPointModelByLoginId(loginId).getAmount());
+            assertEquals(8L, productService.getProductByProductId(productId).get().getStock());
 
         }
 
@@ -171,11 +189,11 @@ public class OrderFacadeIntegrationTest {
             );
 
             // Act & Assert
-            Assertions.assertThrows( CoreException.class, () -> orderFacade.createOrderFromCart(user, usercoupon.getUserCouponId()));
+            Assertions.assertThrows(CoreException.class, () -> orderFacade.createOrderFromCart(user, usercoupon.getUserCouponId()));
 
-            Assertions.assertEquals(0, orderJpaRepository.findAll().size());
-            Assertions.assertEquals(10L, productService.getProductByProductId(productId).get().getStock());
-            Assertions.assertEquals(100L, pointService.getPointModelByLoginId(loginId).getAmount());
+            assertEquals(0, orderJpaRepository.findAll().size());
+            assertEquals(10L, productService.getProductByProductId(productId).get().getStock());
+            assertEquals(100L, pointService.getPointModelByLoginId(loginId).getAmount());
         }
 
         @DisplayName("재고가 부족한 경우 주문은 실패하고, 전체 롤백된다.")
@@ -193,10 +211,10 @@ public class OrderFacadeIntegrationTest {
             pointService.savePoint(new PointModel(loginId, 100000L));
 
             UserModel user = new UserModel(
-              loginId,
-              "email@test.com",
-              "1999-01-01",
-              "W"
+                    loginId,
+                    "email@test.com",
+                    "1999-01-01",
+                    "W"
             );
             userJpaRepository.save(user);
 
@@ -211,11 +229,11 @@ public class OrderFacadeIntegrationTest {
             cartItemJpaRepository.save(new CartItemModel(UUID.randomUUID().toString(), cart.getCartId(), productId, quantity, price));
 
             // Act Assert
-            Assertions.assertThrows( CoreException.class, () -> orderFacade.createOrderFromCart(user, usercoupon.getUserCouponId()));
+            Assertions.assertThrows(CoreException.class, () -> orderFacade.createOrderFromCart(user, usercoupon.getUserCouponId()));
 
-            Assertions.assertEquals(0, orderJpaRepository.findAll().size());
-            Assertions.assertEquals(1L, productService.getProductByProductId(productId).get().getStock());
-            Assertions.assertEquals(100000L, pointService.getPointModelByLoginId(loginId).getAmount());
+            assertEquals(0, orderJpaRepository.findAll().size());
+            assertEquals(1L, productService.getProductByProductId(productId).get().getStock());
+            assertEquals(100000L, pointService.getPointModelByLoginId(loginId).getAmount());
         }
 
         @DisplayName("쿠폰에서 작업이 실패할 경우 롤백처리한다.")
@@ -252,9 +270,9 @@ public class OrderFacadeIntegrationTest {
                 orderFacade.createOrderFromCart(user, invalidUserCoupon.getCouponId());
             });
 
-            Assertions.assertEquals(0, orderJpaRepository.findAll().size());
-            Assertions.assertEquals(5L, productService.getProductByProductId(productId).get().getStock());
-            Assertions.assertEquals(5000L, pointService.getPointModelByLoginId(loginId).getAmount());
+            assertEquals(0, orderJpaRepository.findAll().size());
+            assertEquals(5L, productService.getProductByProductId(productId).get().getStock());
+            assertEquals(5000L, pointService.getPointModelByLoginId(loginId).getAmount());
         }
 
 
@@ -263,7 +281,7 @@ public class OrderFacadeIntegrationTest {
         class CoCurrencyOrderCheck {
             @DisplayName("동일한 상품에 대해 여러 주문이 동시에 요청되어도, 재고가 정상적으로 차감된다.")
             @Test
-            void stockIsCorrectlyDecreased_whenMultipleOrderRequestSameProduct()throws InterruptedException{
+            void stockIsCorrectlyDecreased_whenMultipleOrderRequestSameProduct() throws InterruptedException {
                 // arrange
                 int threadCount = 30;
                 int countDownLatchCount = 40;
@@ -290,10 +308,10 @@ public class OrderFacadeIntegrationTest {
                         )
                 );
 
-                for(int i = 0; i < countDownLatchCount; i++){
+                for (int i = 0; i < countDownLatchCount; i++) {
                     final int idx = i;
                     executorService.submit(() -> {
-                       try {
+                        try {
                             String loginId = "user123" + idx;
                             UserModel user = new UserModel(loginId, loginId + "@test.com", "1999-01-01", "M");
                             userJpaRepository.save(user);
@@ -314,102 +332,209 @@ public class OrderFacadeIntegrationTest {
 
                             orderFacade.createOrderFromCart(user, "userCoupon" + idx);
 
-                       } catch (Exception e){
-                           System.out.println("에러::::::: " + e.getMessage());
-                       }finally {
-                           countDownLatch.countDown();
-                       }
+                        } catch (Exception e) {
+                            System.out.println("에러::::::: " + e.getMessage());
+                        } finally {
+                            countDownLatch.countDown();
+                        }
 
                     });
                 }
                 countDownLatch.await();
 
                 ProductModel finalProduct = productService.getProductByProductId(productId).orElseThrow();
-                Assertions.assertEquals(0L, finalProduct.getStock());
+                assertEquals(0L, finalProduct.getStock());
 
-                Assertions.assertEquals(20, orderJpaRepository.findAll().size());
+                assertEquals(20, orderJpaRepository.findAll().size());
             }
+
+            @DisplayName("동일한 유저가 서로 다른 주문을 동시에 수행해도, 포인트가 정상적으로 차감된다.")
+            @Test
+            void pointIsCorrectlyDeducted_whenSameUserPlacesDifferentOrdersConcurrently() throws InterruptedException {
+                // arrange
+                // arrange
+                String loginId = "user123";
+                String productId = "P001";
+                String couponId = "coupon001";
+                String userCouponId = "userCoupon001";
+                long price = 1000L;
+
+                // 유저 생성 & 저장
+                UserModel user = userJpaRepository.save(
+                        new UserModel(loginId, loginId + "@t.com", "1999-01-01", "M")
+                );
+
+                // 상품 생성 & 저장
+                productService.saveProduct(
+                        new ProductModel(productId, "상품", "설명", "B001", price, 1000L)
+                );
+
+                // 포인트 생성 & 저장
+                pointService.savePoint(new PointModel(loginId, 1_000_000L));
+
+                // 쿠폰 생성 & 저장
+                couponJpaRepository.save(
+                        new CouponModel(couponId, FIXED, 5000L, null, PRODUCT, productId, "2025-01-01", "2025-12-31")
+                );
+
+                // 유저 쿠폰 발급 (모든 스레드가 같은 쿠폰 사용)
+                userCouponJapRepository.save(
+                        new UserCouponModel(userCouponId, loginId, couponId, "2025-01-01")
+                );
+
+                // 장바구니 미리 생성 (Deadlock 방지)
+                CartModel cart = cartService.getOrCreateCart(user);
+
+                int threadCount = 10;
+                ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+                CountDownLatch startLatch = new CountDownLatch(1);
+                CountDownLatch doneLatch = new CountDownLatch(threadCount);
+
+                AtomicInteger successCount = new AtomicInteger();
+                AtomicInteger alreadyUsedCount = new AtomicInteger();
+                AtomicInteger deadlockCount = new AtomicInteger();
+
+                for (int i = 0; i < threadCount; i++) {
+                    executor.submit(() -> {
+                        try {
+                            // 장바구니 아이템만 추가 (cart 생성 안 함)
+                            cartItemJpaRepository.save(new CartItemModel(
+                                    UUID.randomUUID().toString(),
+                                    cart.getCartId(),
+                                    productId,
+                                    1L,
+                                    price
+                            ));
+
+                            startLatch.await(); // 동시에 시작
+                            orderFacade.createOrderFromCart(user, userCouponId);
+                            successCount.incrementAndGet();
+                        } catch (CoreException e) {
+                            if (e.getMessage().contains("이미 사용된 쿠폰")) {
+                                alreadyUsedCount.incrementAndGet();
+                            } else {
+                                System.out.println("다른 CoreException 발생: " + e.getMessage());
+                            }
+                        } catch (CannotAcquireLockException e) {
+                            // Deadlock 방지용 카운트
+                            deadlockCount.incrementAndGet();
+                        } catch (Exception e) {
+                            e.printStackTrace();
+                        } finally {
+                            doneLatch.countDown();
+                        }
+                    });
+                }
+
+                // 모든 스레드 시작
+                startLatch.countDown();
+                doneLatch.await();
+
+                // assert
+                assertEquals(1, successCount.get(), "쿠폰이 적용된 주문은 1건이어야 한다");
+                assertEquals(threadCount - 1, alreadyUsedCount.get(), "나머지는 쿠폰 이미 사용 예외여야 한다");
+
+                // 쿠폰은 최종적으로 사용 상태여야 함
+                UserCouponModel usedCoupon = userCouponJapRepository.findById(userCouponId).orElseThrow();
+                assertTrue(usedCoupon.isUsed());
+
+                System.out.println("성공: " + successCount.get());
+                System.out.println("이미 사용 예외: " + alreadyUsedCount.get());
+                System.out.println("Deadlock 예외: " + deadlockCount.get());
+            }
+
         }
-
-        @DisplayName("동일한 유저가 서로 다른 주문을 동시에 수행해도, 포인트가 정상적으로 차감된다.")
+        @DisplayName("동일한 쿠폰으로 여러 기기에서 동시에 주문해도, 쿠폰은 단 한번만 사용된다.")
         @Test
-        void pointIsCorrectlyDeducted_whenSameUserPlacesDifferentOrdersConcurrently()throws InterruptedException{
+        void onlyOneCouponUsage_shouldBeAllowed_whenMultipleThreadsAttemptToUseSameCoupon() throws InterruptedException {
             // arrange
-
             String loginId = "user123";
-            String productId = "p001";
+            String productId = "P001";
+            String couponId = "coupon001";
+            String userCouponId = "userCoupon001";
             long price = 1000L;
-            long userPoint = 500_00L;
 
-            UserModel user = new UserModel(
-                    loginId,
-                    loginId + "@test.com",
-                    "1999-01-01",
-                    "M"
+            // 유저 생성 & 저장
+            UserModel user = userJpaRepository.save(
+                    new UserModel(loginId, loginId + "@t.com", "1999-01-01", "M")
             );
-            userJpaRepository.save(user);
 
-            pointService.savePoint(new PointModel(loginId, userPoint));
-            productService.saveProduct(new ProductModel(productId, "신발", "런닝화", "b001", price, 100L));
+            // 상품 생성 & 저장
+            productService.saveProduct(
+                    new ProductModel(productId, "운동화", "런닝화", "B001", price, 1000L)
+            );
+
+            // 포인트 생성 & 저장
+            pointService.savePoint(new PointModel(loginId, 1_000_000L));
+
+            // 쿠폰 생성 & 저장
             couponJpaRepository.save(
-                    new CouponModel(
-                            "counpon123",
-                            FIXED,
-                            5000L,
-                            null,
-                            PRODUCT,
-                            productId,
-                            "2025-01-01",
-                            "2025-12-31"
-                    )
+                    new CouponModel(couponId, FIXED, 5000L, null, PRODUCT, productId, "2025-01-01", "2025-12-31")
             );
-            int threadCount = 30;
-            int countDownLatchCount = 40;
-            ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
-            CountDownLatch countDownLatch = new CountDownLatch(countDownLatchCount);
 
-            for(int i = 0; i < countDownLatchCount; i++){
+            // 유저 쿠폰 발급
+            userCouponJapRepository.save(
+                    new UserCouponModel(userCouponId, loginId, couponId, "2025-01-01")
+            );
+
+            int threadCount = 10;
+            ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+            CountDownLatch startLatch = new CountDownLatch(1);
+            CountDownLatch doneLatch = new CountDownLatch(threadCount);
+            AtomicInteger couponAppliedCount = new AtomicInteger();
+            AtomicInteger couponFailCount = new AtomicInteger();
+
+            CartModel cart =  new CartModel(
+                    "cart123",
+                    loginId,
+                    0,
+                    0
+            );
+            cartJpaRepository.save(cart);
+
+
+            for (int i = 0; i < threadCount; i++) {
                 int idx = i;
-                executorService.submit(() -> {
-                   try {
-                       CartModel cart = cartService.getOrCreateCart(user);
-                       cartItemJpaRepository.save(new CartItemModel(
-                               UUID.randomUUID().toString(),
-                               cart.getCartId(),
-                               productId,
-                               1L,
-                               price
-                       ));
+                executor.submit(() -> {
+                    try {
+                        cartItemJpaRepository.save(
+                                new CartItemModel(UUID.randomUUID().toString(), cart.getCartId(), productId, 1L, price)
+                        );
+                        cartItemJpaRepository.flush();
 
-                       UserCouponModel userCoupon = new UserCouponModel(
-                               "coupon" + idx,
-                               loginId,
-                               "counpon123",
-                               "2025-01-01"
-                       );
-                       userCouponJapRepository.save(userCoupon);
-
-                       orderFacade.createOrderFromCart(user, userCoupon.getUserCouponId());
-                   } catch (Exception e) {
-                       System.out.println("error:::::: " + e.getMessage());
-                   } finally {
-                       countDownLatch.countDown();
-                   }
+                        startLatch.await();
+                        orderFacade.createOrderFromCart(user, userCouponId);
+                        couponAppliedCount.incrementAndGet();
+                    } catch (CoreException e) {
+                        if (e.getMessage().contains("이미 사용된 쿠폰")) {
+                            couponFailCount.incrementAndGet();
+                        } else {
+                            System.out.println("다른 CoreException: " + e.getMessage());
+                        }
+                    } catch (ObjectOptimisticLockingFailureException | OptimisticLockException e) {
+                        couponFailCount.incrementAndGet();
+                    } catch (Exception e) {
+                        System.out.println("error :::: " + idx + "ddd " + e.getMessage());
+                    } finally {
+                        doneLatch.countDown();
+                    }
                 });
             }
-            countDownLatch.await();
+
+            // 모든 스레드 시작
+            startLatch.countDown();
+            doneLatch.await();
 
             // assert
-            long totalOrderPrice = orderJpaRepository.findAll()
-                    .stream()
-                    .mapToLong(OrderModel::getTotalPrice)
-                    .sum();
-            long expectedPoint = userPoint - totalOrderPrice;
-            long realPoint = pointService.getPointModelByLoginId(loginId).getAmount();
+            assertEquals(1, couponAppliedCount.get(), "쿠폰이 적용된 주문은 1건이어야 한다");
+            assertEquals(threadCount - 1, couponFailCount.get(), "나머지는 쿠폰 이미 사용 예외여야 한다");
 
-            Assertions.assertEquals(expectedPoint, realPoint);
-
+            UserCouponModel usedCoupon = userCouponJapRepository.findById(userCouponId).orElseThrow();
+            assertTrue(usedCoupon.isUsed(), "쿠폰은 사용 상태여야 한다");
         }
+
+
     }
+
 
 }

--- a/apps/commerce-api/src/test/java/com/loopers/domain/userCoupon/UserCouponModelTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/userCoupon/UserCouponModelTest.java
@@ -1,0 +1,67 @@
+package com.loopers.domain.userCoupon;
+
+import com.loopers.domain.user.UserModel;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class UserCouponModelTest {
+
+    @DisplayName("사용자의 쿠폰을 사용할 때,")
+    @Nested
+    class ApplyCoupon{
+        @DisplayName("사용자의 로그인아이디와 쿠폰의 로그인아이디가 같지 않은 경우, 에러를 반환한다.")
+        @Test
+        void returnErrorCode_whenUserLoginIdIsNotEqualsUserCouponLoginId(){
+            // arrange
+            UserModel user = new UserModel(
+                    "login123",
+                    "email@email.com",
+                    "1999-01-01",
+                    "W"
+            );
+
+            UserCouponModel userCouponModel = new UserCouponModel(
+                    "usercoupon123",
+                    "user123",
+                    "coupon123",
+                    ""
+            );
+
+            // act assert
+            CoreException result = assertThrows(CoreException.class, () -> {
+                userCouponModel.validateOwner(user);
+            });
+
+            assertEquals(ErrorType.NOT_FOUND, result.getErrorType());
+        }
+
+        @DisplayName("이미사용한 쿠폰이라면, 에러를 반환한다.")
+        @Test
+        void returnErrorCode_whenUserCouponIsUsed(){
+            // arrange
+            UserCouponModel userCouponModel = new UserCouponModel(
+                    "usercoupon123",
+                    "user123",
+                    "coupon123",
+                    "2029-03-05"
+            );
+            userCouponModel.use();
+
+            // act
+            CoreException result = assertThrows(CoreException.class, () -> {
+                userCouponModel.use();
+            });
+
+            // assert
+            assertThat(result.getErrorType()).isEqualTo(ErrorType.BAD_REQUEST);
+
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/userCoupon/UserCouponServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/userCoupon/UserCouponServiceTest.java
@@ -1,0 +1,52 @@
+package com.loopers.domain.userCoupon;
+
+import com.loopers.domain.coupon.CouponService;
+import com.loopers.infrastructure.coupon.CouponJpaRepository;
+import com.loopers.infrastructure.userCoupon.UserCouponJapRepository;
+import com.loopers.support.error.CoreException;
+import com.loopers.support.error.ErrorType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.testcontainers.shaded.org.checkerframework.checker.units.qual.A;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+
+@SpringBootTest
+public class UserCouponServiceTest {
+
+    @Autowired
+    private UserCouponService userCouponService;
+
+    @Autowired
+    private UserCouponJapRepository userCouponJpaRepository;
+
+    @DisplayName("사용자의 쿠폰을 조회할 때")
+    @Nested
+    class GetUserCoupon {
+        @DisplayName("사용자의 쿠폰이 존재하지 않으면, 에러를 반환한다.")
+        @Test
+        void retrunNotFound_whenUserCouponIsNotExist() {
+            // arrange
+            UserCouponModel usercoupon = new UserCouponModel(
+                    "",
+                    "user123",
+                    "coupon123",
+                    "2025-01-01"
+            );
+
+            // act + assert
+            CoreException result = assertThrows(CoreException.class, () ->
+                    userCouponService.getUserCoupon(usercoupon)
+            );
+
+            assertThat(result.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
+        }
+    }
+}

--- a/apps/commerce-api/src/test/java/com/loopers/domain/userCoupon/UserCouponServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/userCoupon/UserCouponServiceTest.java
@@ -43,7 +43,7 @@ public class UserCouponServiceTest {
 
             // act + assert
             CoreException result = assertThrows(CoreException.class, () ->
-                    userCouponService.getUserCoupon(usercoupon)
+                    userCouponService.getUserCoupon(usercoupon.getUserCouponId())
             );
 
             assertThat(result.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);

--- a/apps/commerce-api/src/test/java/com/loopers/domain/userCoupon/UserCouponServiceTest.java
+++ b/apps/commerce-api/src/test/java/com/loopers/domain/userCoupon/UserCouponServiceTest.java
@@ -43,10 +43,11 @@ public class UserCouponServiceTest {
 
             // act + assert
             CoreException result = assertThrows(CoreException.class, () ->
-                    userCouponService.getUserCoupon(usercoupon.getUserCouponId())
+                    userCouponService.getUserCouponByUserCouponId(usercoupon.getUserCouponId())
             );
 
             assertThat(result.getErrorType()).isEqualTo(ErrorType.NOT_FOUND);
         }
+
     }
 }


### PR DESCRIPTION

## 💬 Review Points
이번 구현에서는 도메인별로 다른 락 전략을 적용했습니다.

**1. 쿠폰 (낙관적락)**
- 쿠폰 사용은 “사용 가능 여부 확인 → 사용 처리”라는 단일 흐름이어서, 충돌이 발생하더라도 재시도 로직으로 충분히 복구 가능하다고 판단했습니다.
- 사용 빈도 대비 동시성 충돌 빈도가 낮고, 락을 잡는 시간 없이 성능에 유리하다고 판단하여 사용했습니다..

2. 포인트/재고 (비관적 락)
- 포인트와 재고는 주문 처리에서 여러 도메인과 강하게 얽혀 있어(포인트 차감 → 재고 차감 → 결제 확정), 중간에 값이 바뀌면 전체 프로세스를 재시작해야된다고 생각하여 비관적 락을 선택하게되었습니다..!

-> 쿠폰은 낙관적 락, 포인트/재고는 비관적 락을 섞어 쓴 현재 설계가 합리적인지 궁금합니다.
-> 혹시 포인트나 재고도 낙관적 락으로 처리하는 편이 나을지, 또는 쿠폰을 비관적으로 처리해야 할 상황이 있을지 리뷰 의견을 받고 싶습니다.

## ✅ Checklist

    - [ ] 포인트 조회 비관적락 추가
    - [ ] 쿠폰 사용 구현
    - [ ] 쿠폰 사용 테스트
    - [ ] 주문하기 원자성 테스트
    - [ ] 재고차감 동시서 구현, 테스트
    - [ ] 동일 유저 포인트 동시성 구현, 테스트
    - [ ] 쿠폰 동시성 구현, 테스트
    - [ ] 좋아요 동시성 테스

